### PR TITLE
Fixing Auto admin access to the repo

### DIFF
--- a/.github/workflows/actions/release-packages/action.yml
+++ b/.github/workflows/actions/release-packages/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - uses: actions/checkout@v2
       with:
-        token: ${{ secrets.ADMIN_TOKEN }}
+        token: ${{ inputs.ADMIN_TOKEN }}
     - name: Prepare repository
       run: git fetch --unshallow --tags
       shell: bash

--- a/.github/workflows/actions/release-packages/action.yml
+++ b/.github/workflows/actions/release-packages/action.yml
@@ -7,9 +7,15 @@ inputs:
   NPM_TOKEN:
     description: NPM_TOKEN used to publish to npm
     required: true
+  ADMIN_TOKEN:
+    description: ADMIN_TOKEN used to access the git repo
+    required: true
 runs:
   using: 'composite'
   steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.ADMIN_TOKEN }}
     - name: Prepare repository
       run: git fetch --unshallow --tags
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,3 +57,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.1--canary.2.a3deb21.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.0.1--canary.2.a3deb21.0
  npm install @ukho/admiralty-core@0.0.1--canary.2.a3deb21.0
  # or 
  yarn add @ukho/admiralty-angular@0.0.1--canary.2.a3deb21.0
  yarn add @ukho/admiralty-core@0.0.1--canary.2.a3deb21.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
