### PR TITLE
Fixing the stylesheets and webfonts missing from the NPM package

### DIFF
--- a/.github/workflows/actions/build-core/action.yml
+++ b/.github/workflows/actions/build-core/action.yml
@@ -16,4 +16,4 @@ runs:
       with:
         name: admiralty-core
         output: admiralty-core.zip
-        paths: ./packages/core/dist ./packages/core/loader
+        paths: ./packages/core/dist ./packages/core/loader ./packages/core/styles

--- a/yarn.lock
+++ b/yarn.lock
@@ -5978,7 +5978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ukho/admiralty-angular@^0.0.4, @ukho/admiralty-angular@workspace:packages/angular":
+"@ukho/admiralty-angular@^0.0.5, @ukho/admiralty-angular@workspace:packages/angular":
   version: 0.0.0-use.local
   resolution: "@ukho/admiralty-angular@workspace:packages/angular"
   dependencies:
@@ -5994,7 +5994,7 @@ __metadata:
     "@angular/platform-browser-dynamic": ~15.2.5
     "@angular/router": ~15.2.5
     "@types/node": ^18.15.11
-    "@ukho/admiralty-core": ^0.0.4
+    "@ukho/admiralty-core": ^0.0.5
     ng-packagr: ^15.2.2
     tslib: ^2.5.0
     typescript: ~4.9.3
@@ -6004,7 +6004,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ukho/admiralty-core@^0.0.4, @ukho/admiralty-core@workspace:packages/core":
+"@ukho/admiralty-core@^0.0.5, @ukho/admiralty-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@ukho/admiralty-core@workspace:packages/core"
   dependencies:
@@ -20560,7 +20560,7 @@ __metadata:
     "@angular/router": ~15.2.5
     "@fortawesome/fontawesome-free": ~6.4.0
     "@types/node": ^18.15.11
-    "@ukho/admiralty-angular": ^0.0.4
+    "@ukho/admiralty-angular": ^0.0.5
     rimraf: ^4.4.1
     rxjs: ~7.8.0
     tslib: ^2.5.0


### PR DESCRIPTION
Fixes #4 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.6--canary.5.7d9a081.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.0.6--canary.5.7d9a081.0
  npm install @ukho/admiralty-core@0.0.6--canary.5.7d9a081.0
  # or 
  yarn add @ukho/admiralty-angular@0.0.6--canary.5.7d9a081.0
  yarn add @ukho/admiralty-core@0.0.6--canary.5.7d9a081.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
