### PR TITLE
Fixing the package version desync

### DIFF
--- a/.github/workflows/actions/release-packages/action.yml
+++ b/.github/workflows/actions/release-packages/action.yml
@@ -35,10 +35,5 @@ runs:
         NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
       run: |
         yarn install --immutable
-        npx auto shipit -vv
+        npx auto shipit
       shell: bash
-    - uses: ./.github/workflows/actions/upload-archive
-      with:
-        name: drop
-        output: drop.zip
-        paths: ./

--- a/.github/workflows/actions/release-packages/action.yml
+++ b/.github/workflows/actions/release-packages/action.yml
@@ -35,7 +35,7 @@ runs:
         NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
       run: |
         yarn install --immutable
-        npx auto shipit
+        npx auto shipit -vv
       shell: bash
     - uses: ./.github/workflows/actions/upload-archive
       with:

--- a/.github/workflows/actions/release-packages/action.yml
+++ b/.github/workflows/actions/release-packages/action.yml
@@ -37,3 +37,8 @@ runs:
         yarn install --immutable
         npx auto shipit
       shell: bash
+    - uses: ./.github/workflows/actions/upload-archive
+      with:
+        name: drop
+        output: drop.zip
+        paths: ./

--- a/packages/angular/.scripts/copyPackageVersion.js
+++ b/packages/angular/.scripts/copyPackageVersion.js
@@ -1,7 +1,0 @@
-const fs = require('fs');
-const rootPackageJson = require('../package.json');
-const distPackageJson = require('../dist/package.json')
-
-distPackageJson.version = rootPackageJson.version;
-
-fs.writeFileSync('./dist/package.json', JSON.stringify(distPackageJson,null, 2))

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -8,10 +8,14 @@
   "fesm2020": "dist/fesm2020/ukho-admiralty-angular.mjs",
   "fesm2015": "dist/fesm2015/ukho-admiralty-angular.mjs",
   "scripts": {
+    "prepare": "rimraf dist/package.json",
     "build": "ng-packagr -p ng-package.json -c tsconfig.json",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"
   },
+  "files": [
+    "dist/"
+  ],
   "peerDependencies": {
     "@angular/common": "^15.2.5",
     "@angular/core": "^15.2.5"
@@ -41,9 +45,6 @@
     "setupFilesAfterEnv": [
       "./setupJest.ts"
     ]
-  },
-  "publishConfig": {
-    "directory": "dist/"
   },
   "license": "MIT",
   "url": "https://github.com/UKHO/admiralty-design-system",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -8,7 +8,6 @@
   "fesm2020": "dist/fesm2020/ukho-admiralty-angular.mjs",
   "fesm2015": "dist/fesm2015/ukho-admiralty-angular.mjs",
   "scripts": {
-    "prepublishOnly": "node .scripts/copyPackageVersion.js",
     "build": "ng-packagr -p ng-package.json -c tsconfig.json",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -8,7 +8,6 @@
   "fesm2020": "dist/fesm2020/ukho-admiralty-angular.mjs",
   "fesm2015": "dist/fesm2015/ukho-admiralty-angular.mjs",
   "scripts": {
-    "prepare": "rimraf dist/package.json",
     "build": "ng-packagr -p ng-package.json -c tsconfig.json",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"


### PR DESCRIPTION
Fixes: #57 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1--canary.60.d408a38.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.1.1--canary.60.d408a38.0
  npm install @ukho/admiralty-core@0.1.1--canary.60.d408a38.0
  # or 
  yarn add @ukho/admiralty-angular@0.1.1--canary.60.d408a38.0
  yarn add @ukho/admiralty-core@0.1.1--canary.60.d408a38.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
