### PR TITLE
fix: admiralty textarea does not support maxlength

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
   "author": "UKHO",
   "auto": {
     "plugins": [
-      "protected-branch",
-      {
-        "requiredStatusChecks": ["build", "test-core-spec","UI Tests","UI Review","chromatic-deployment"]
-      },
+      [
+        "protected-branch",
+        {
+          "requiredStatusChecks": ["build", "test-core-spec","UI Tests","UI Review","chromatic-deployment"]
+        }
+      ],
       "npm",
       "conventional-commits",
       "released"

--- a/package.json
+++ b/package.json
@@ -28,13 +28,7 @@
   "license": "MIT",
   "author": "UKHO",
   "auto": {
-    "plugins": [
-      [
-        "protected-branch",
-        {
-          "requiredStatusChecks": ["build", "test-core-spec","UI Tests","UI Review","chromatic-deployment"]
-        }
-      ],
+    "plugins": [      
       "npm",
       "conventional-commits",
       "released"

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -1018,14 +1018,14 @@ export declare interface AdmiraltyTableRow extends Components.AdmiraltyTableRow 
 
 
 @ProxyCmp({
-  inputs: ['disabled', 'hint', 'invalid', 'invalidMessage', 'label', 'text', 'width']
+  inputs: ['disabled', 'hint', 'invalid', 'invalidMessage', 'label', 'maxLength', 'text', 'width']
 })
 @Component({
   selector: 'admiralty-textarea',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['disabled', 'hint', 'invalid', 'invalidMessage', 'label', 'text', 'width'],
+  inputs: ['disabled', 'hint', 'invalid', 'invalidMessage', 'label', 'maxLength', 'text', 'width'],
 })
 export class AdmiraltyTextarea {
   protected el: HTMLElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -522,6 +522,10 @@ export namespace Components {
          */
         "label": string;
         /**
+          * The maximum string length for the input field.
+         */
+        "maxLength"?: number;
+        /**
           * The contents of the textarea
          */
         "text": string;
@@ -1568,6 +1572,10 @@ declare namespace LocalJSX {
           * The label which will be used as a placeholder in the unfilled state, and as a field label in the filled state.
          */
         "label"?: string;
+        /**
+          * The maximum string length for the input field.
+         */
+        "maxLength"?: number;
         /**
           * Event is fired when the form control loses focus
           * @event textareaBlur

--- a/packages/core/src/components/textarea/readme.md
+++ b/packages/core/src/components/textarea/readme.md
@@ -14,6 +14,7 @@
 | `invalid`        | `invalid`         | Whether to show the input in an invalid state                                                                  | `boolean` | `false`     |
 | `invalidMessage` | `invalid-message` | The message to show when the input is invalid                                                                  | `string`  | `undefined` |
 | `label`          | `label`           | The label which will be used as a placeholder in the unfilled state, and as a field label in the filled state. | `string`  | `''`        |
+| `maxLength`      | `max-length`      | The maximum string length for the input field.                                                                 | `number`  | `undefined` |
 | `text`           | `text`            | The contents of the textarea                                                                                   | `string`  | `''`        |
 | `width`          | `width`           | The maximum width for the input field.                                                                         | `number`  | `undefined` |
 

--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -6,60 +6,49 @@ const meta: Meta = {
   component: 'admiralty-side-nav-item',
   title: 'Forms/Text Area',
   parameters: {
-    actions: {
-    }
-  }
+    actions: {},
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<TextareaComponent>;
-  
-export const Basic: Story = { render: args => 
-  html`
-    <admiralty-textarea label="${args.label}" hint="${args.hint}">
-    </admiralty-textarea>`,
+
+export const Basic: Story = {
+  render: args => html` <admiralty-textarea label="${args.label}" hint="${args.hint}"> </admiralty-textarea>`,
   args: {
     label: 'Description',
-    hint: 'Enter a description'
-  }
+    hint: 'Enter a description',
+  },
 };
-  
-export const FixedWidth: Story = { render: args => 
-  html`
-    <admiralty-textarea label="${args.label}" width="${args.width}">
-    </admiralty-textarea>`,
+
+export const FixedWidth: Story = {
+  render: args => html` <admiralty-textarea label="${args.label}" width="${args.width}"> </admiralty-textarea>`,
   args: {
     label: 'Description',
-    width: 400
-  }
+    width: 400,
+  },
 };
-  
-export const Disabled: Story = { render: args => 
-  html`
-    <admiralty-textarea label="${args.label}" ?disabled="${args.disabled}">
-    </admiralty-textarea>`,
+
+export const Disabled: Story = {
+  render: args => html` <admiralty-textarea label="${args.label}" ?disabled="${args.disabled}"> </admiralty-textarea>`,
   args: {
     label: 'Description',
-    disabled: true
-  }
+    disabled: true,
+  },
 };
-  
-export const Invalid: Story = { render: args => 
-  html`
-    <admiralty-textarea label="${args.label}" ?invalid="${args.invalid}" invalid-message="${args.invalidMessage}">
-    </admiralty-textarea>`,
+
+export const Invalid: Story = {
+  render: args => html` <admiralty-textarea label="${args.label}" ?invalid="${args.invalid}" invalid-message="${args.invalidMessage}"> </admiralty-textarea>`,
   args: {
     label: 'What is your name?',
     invalid: true,
-    invalidMessage: 'That is not a real name'
-  }
+    invalidMessage: 'That is not a real name',
+  },
 };
-  
-export const WithText: Story = { render: args => 
-  html`
-    <admiralty-textarea label="${args.label}" text="${args.text}">
-    </admiralty-textarea>`,
+
+export const WithText: Story = {
+  render: args => html` <admiralty-textarea label="${args.label}" text="${args.text}"> </admiralty-textarea>`,
   args: {
     label: 'With text',
     text: 'Sample Text',

--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -63,5 +63,13 @@ export const WithText: Story = { render: args =>
   args: {
     label: 'With text',
     text: 'Sample Text',
-  }
+  },
+};
+
+export const MaxLength: Story = {
+  render: args => html` <admiralty-textarea text="${args.text}" max-length="${args.maxLength}"> </admiralty-textarea>`,
+  args: {
+    maxLength: 1,
+    text: 'A',
+  },
 };

--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -31,6 +31,11 @@ export class TextareaComponent {
   @Prop() width?: number;
 
   /**
+   * The maximum string length for the input field.
+   */
+  @Prop() maxLength?: number;
+
+  /**
    * This dictates whether the form field is disabled.
    */
   @Prop() disabled: boolean = false;
@@ -78,6 +83,7 @@ export class TextareaComponent {
             class={{ disabled: this.disabled, invalid: this.invalid }}
             style={this.width ? { maxWidth: `${this.width}px` } : {}}
             id={this.inputId}
+            maxlength={this.maxLength}
             onChange={this.onChange}
             onBlur={this.onBlur}
           >


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.2--canary.65.baab903.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.1.2--canary.65.baab903.0
  npm install @ukho/admiralty-core@0.1.2--canary.65.baab903.0
  # or 
  yarn add @ukho/admiralty-angular@0.1.2--canary.65.baab903.0
  yarn add @ukho/admiralty-core@0.1.2--canary.65.baab903.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
