### PR TITLE
Adding a custom file input event

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -12,4 +12,9 @@ export { BooleanValueAccessor } from './lib/stencil-generated/boolean-value-acce
 export { NumericValueAccessor } from './lib/stencil-generated/number-value-accessor';
 export { SelectValueAccessor } from './lib/stencil-generated/select-value-accessor';
 
-export { CheckboxChangeEventDetail, SelectChangeEventDetail, RadioGroupChangeEventDetail } from '@ukho/admiralty-core';
+export {
+  CheckboxChangeEventDetail,
+  SelectChangeEventDetail,
+  RadioGroupChangeEventDetail,
+  FileInputChangeEventDetail,
+} from '@ukho/admiralty-core';

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -224,11 +224,13 @@ export class AdmiraltyFileInput {
 }
 
 
+import type { FileInputChangeEventDetail as IAdmiraltyFileInputFileInputChangeEventDetail } from '@ukho/admiralty-core';
+
 export declare interface AdmiraltyFileInput extends Components.AdmiraltyFileInput {
   /**
    * Emitted when the added file(s) changes
    */
-  fileInputChange: EventEmitter<CustomEvent<File[]>>;
+  fileInputChange: EventEmitter<CustomEvent<IAdmiraltyFileInputFileInputChangeEventDetail>>;
 }
 
 

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -8,6 +8,7 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { ButtonVariant } from "./components/button/button.types";
 import { IconName, IconPrefix } from "@fortawesome/fontawesome-svg-core";
 import { CheckboxChangeEventDetail } from "./components/checkbox/checkbox.interface";
+import { FileInputChangeEventDetail } from "./components/file-input/file-input.interface";
 import { IconName as IconName1 } from "@fortawesome/free-solid-svg-icons";
 import { InputChangeEventDetail } from "./components/input/input.interface";
 import { RadioGroupChangeEventDetail } from "./components/radio-group/radio-group-interface";
@@ -15,6 +16,7 @@ import { SelectChangeEventDetail } from "./components/select/select.interface";
 export { ButtonVariant } from "./components/button/button.types";
 export { IconName, IconPrefix } from "@fortawesome/fontawesome-svg-core";
 export { CheckboxChangeEventDetail } from "./components/checkbox/checkbox.interface";
+export { FileInputChangeEventDetail } from "./components/file-input/file-input.interface";
 export { IconName as IconName1 } from "@fortawesome/free-solid-svg-icons";
 export { InputChangeEventDetail } from "./components/input/input.interface";
 export { RadioGroupChangeEventDetail } from "./components/radio-group/radio-group-interface";
@@ -1124,7 +1126,7 @@ declare namespace LocalJSX {
         /**
           * Emitted when the added file(s) changes
          */
-        "onFileInputChange"?: (event: AdmiraltyFileInputCustomEvent<File[]>) => void;
+        "onFileInputChange"?: (event: AdmiraltyFileInputCustomEvent<FileInputChangeEventDetail>) => void;
     }
     interface AdmiraltyFilter {
         /**

--- a/packages/core/src/components/file-input/file-input.interface.ts
+++ b/packages/core/src/components/file-input/file-input.interface.ts
@@ -1,0 +1,3 @@
+export interface FileInputChangeEventDetail {
+  files: File[];
+}

--- a/packages/core/src/components/file-input/file-input.spec.ts
+++ b/packages/core/src/components/file-input/file-input.spec.ts
@@ -107,6 +107,6 @@ describe('file-input', () => {
 
     comp.changeHandler(event as unknown as Event);
 
-    expect(eventSpy).toBeCalledWith([file]);
+    expect(eventSpy).toBeCalledWith({ files: [file] });
   });
 });

--- a/packages/core/src/components/file-input/file-input.tsx
+++ b/packages/core/src/components/file-input/file-input.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Event, Host, h, Prop, State, EventEmitter } from '@stencil/core';
+import { FileInputChangeEventDetail } from './file-input.interface';
 
 @Component({
   tag: 'admiralty-file-input',
@@ -21,7 +22,7 @@ export class FileInputComponent {
   /**
    * Emitted when the added file(s) changes
    */
-  @Event() fileInputChange: EventEmitter<File[]>;
+  @Event() fileInputChange: EventEmitter<FileInputChangeEventDetail>;
 
   id: string = `admiralty-file-input-${++nextId}`;
 
@@ -39,7 +40,7 @@ export class FileInputComponent {
 
     this.storeFileInfo((event.target as HTMLInputElement).files);
 
-    this.fileInputChange.emit(this.files);
+    this.fileInputChange.emit({ files: this.files });
     console.log('changeHandler:', this.files);
   }
 
@@ -78,7 +79,7 @@ export class FileInputComponent {
 
     if (event.dataTransfer.files) {
       this.storeFileInfo(event.dataTransfer.files);
-      this.fileInputChange.emit(this.files);
+      this.fileInputChange.emit({ files: this.files });
       console.log('Drop: ', this.files);
     }
   }

--- a/packages/core/src/components/file-input/readme.md
+++ b/packages/core/src/components/file-input/readme.md
@@ -15,9 +15,9 @@
 
 ## Events
 
-| Event             | Description                            | Type                  |
-| ----------------- | -------------------------------------- | --------------------- |
-| `fileInputChange` | Emitted when the added file(s) changes | `CustomEvent<File[]>` |
+| Event             | Description                            | Type                                      |
+| ----------------- | -------------------------------------- | ----------------------------------------- |
+| `fileInputChange` | Emitted when the added file(s) changes | `CustomEvent<FileInputChangeEventDetail>` |
 
 
 ## Dependencies


### PR DESCRIPTION
Fixes #77 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.2--canary.75.9ff44a4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.3.2--canary.75.9ff44a4.0
  npm install @ukho/admiralty-core@0.3.2--canary.75.9ff44a4.0
  # or 
  yarn add @ukho/admiralty-angular@0.3.2--canary.75.9ff44a4.0
  yarn add @ukho/admiralty-core@0.3.2--canary.75.9ff44a4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
