### PR TITLE
Fix textarea so that it works with the Angular form controls

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -12,4 +12,9 @@ export { BooleanValueAccessor } from './lib/stencil-generated/boolean-value-acce
 export { NumericValueAccessor } from './lib/stencil-generated/number-value-accessor';
 export { SelectValueAccessor } from './lib/stencil-generated/select-value-accessor';
 
-export { CheckboxChangeEventDetail, SelectChangeEventDetail, RadioGroupChangeEventDetail } from '@ukho/admiralty-core';
+export {
+  CheckboxChangeEventDetail,
+  SelectChangeEventDetail,
+  RadioGroupChangeEventDetail,
+  TextAreaChangeEventDetail,
+} from '@ukho/admiralty-core';

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -1018,24 +1018,26 @@ export declare interface AdmiraltyTableRow extends Components.AdmiraltyTableRow 
 
 
 @ProxyCmp({
-  inputs: ['disabled', 'hint', 'invalid', 'invalidMessage', 'label', 'maxLength', 'text', 'width']
+  inputs: ['disabled', 'hint', 'invalid', 'invalidMessage', 'label', 'maxLength', 'value', 'width']
 })
 @Component({
   selector: 'admiralty-textarea',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['disabled', 'hint', 'invalid', 'invalidMessage', 'label', 'maxLength', 'text', 'width'],
+  inputs: ['disabled', 'hint', 'invalid', 'invalidMessage', 'label', 'maxLength', 'value', 'width'],
 })
 export class AdmiraltyTextarea {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['textareaBlur', 'textareaChanged']);
+    proxyOutputs(this, this.el, ['textareaBlur', 'admiraltyChange']);
   }
 }
 
+
+import type { TextAreaChangeEventDetail as IAdmiraltyTextareaTextAreaChangeEventDetail } from '@ukho/admiralty-core';
 
 export declare interface AdmiraltyTextarea extends Components.AdmiraltyTextarea {
   /**
@@ -1043,9 +1045,9 @@ export declare interface AdmiraltyTextarea extends Components.AdmiraltyTextarea 
    */
   textareaBlur: EventEmitter<CustomEvent<any>>;
   /**
-   * Event is fired when the form control changes @event textareaChanged
+   * Event is fired when the form control changes @event admiraltyChange
    */
-  textareaChanged: EventEmitter<CustomEvent<string>>;
+  admiraltyChange: EventEmitter<CustomEvent<IAdmiraltyTextareaTextAreaChangeEventDetail>>;
 }
 
 

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -12,6 +12,7 @@ import { IconName as IconName1 } from "@fortawesome/free-solid-svg-icons";
 import { InputChangeEventDetail } from "./components/input/input.interface";
 import { RadioGroupChangeEventDetail } from "./components/radio-group/radio-group-interface";
 import { SelectChangeEventDetail } from "./components/select/select.interface";
+import { TextAreaChangeEventDetail } from "./components/textarea/textarea.interface";
 export { ButtonVariant } from "./components/button/button.types";
 export { IconName, IconPrefix } from "@fortawesome/fontawesome-svg-core";
 export { CheckboxChangeEventDetail } from "./components/checkbox/checkbox.interface";
@@ -19,6 +20,7 @@ export { IconName as IconName1 } from "@fortawesome/free-solid-svg-icons";
 export { InputChangeEventDetail } from "./components/input/input.interface";
 export { RadioGroupChangeEventDetail } from "./components/radio-group/radio-group-interface";
 export { SelectChangeEventDetail } from "./components/select/select.interface";
+export { TextAreaChangeEventDetail } from "./components/textarea/textarea.interface";
 export namespace Components {
     interface AdmiraltyBreadcrumb {
         /**
@@ -526,9 +528,9 @@ export namespace Components {
          */
         "maxLength"?: number;
         /**
-          * The contents of the textarea
+          * The value of the textarea.
          */
-        "text": string;
+        "value"?: string | number | null;
         /**
           * The maximum width for the input field.
          */
@@ -1577,19 +1579,19 @@ declare namespace LocalJSX {
          */
         "maxLength"?: number;
         /**
+          * Event is fired when the form control changes
+          * @event admiraltyChange
+         */
+        "onAdmiraltyChange"?: (event: AdmiraltyTextareaCustomEvent<TextAreaChangeEventDetail>) => void;
+        /**
           * Event is fired when the form control loses focus
           * @event textareaBlur
          */
         "onTextareaBlur"?: (event: AdmiraltyTextareaCustomEvent<any>) => void;
         /**
-          * Event is fired when the form control changes
-          * @event textareaChanged
+          * The value of the textarea.
          */
-        "onTextareaChanged"?: (event: AdmiraltyTextareaCustomEvent<string>) => void;
-        /**
-          * The contents of the textarea
-         */
-        "text"?: string;
+        "value"?: string | number | null;
         /**
           * The maximum width for the input field.
          */

--- a/packages/core/src/components/textarea/readme.md
+++ b/packages/core/src/components/textarea/readme.md
@@ -7,24 +7,24 @@
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                                                    | Type      | Default     |
-| ---------------- | ----------------- | -------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `disabled`       | `disabled`        | This dictates whether the form field is disabled.                                                              | `boolean` | `false`     |
-| `hint`           | `hint`            | The hint which will be used under the label to describe the input.                                             | `string`  | `undefined` |
-| `invalid`        | `invalid`         | Whether to show the input in an invalid state                                                                  | `boolean` | `false`     |
-| `invalidMessage` | `invalid-message` | The message to show when the input is invalid                                                                  | `string`  | `undefined` |
-| `label`          | `label`           | The label which will be used as a placeholder in the unfilled state, and as a field label in the filled state. | `string`  | `''`        |
-| `maxLength`      | `max-length`      | The maximum string length for the input field.                                                                 | `number`  | `undefined` |
-| `text`           | `text`            | The contents of the textarea                                                                                   | `string`  | `''`        |
-| `width`          | `width`           | The maximum width for the input field.                                                                         | `number`  | `undefined` |
+| Property         | Attribute         | Description                                                                                                    | Type               | Default     |
+| ---------------- | ----------------- | -------------------------------------------------------------------------------------------------------------- | ------------------ | ----------- |
+| `disabled`       | `disabled`        | This dictates whether the form field is disabled.                                                              | `boolean`          | `false`     |
+| `hint`           | `hint`            | The hint which will be used under the label to describe the input.                                             | `string`           | `undefined` |
+| `invalid`        | `invalid`         | Whether to show the input in an invalid state                                                                  | `boolean`          | `false`     |
+| `invalidMessage` | `invalid-message` | The message to show when the input is invalid                                                                  | `string`           | `undefined` |
+| `label`          | `label`           | The label which will be used as a placeholder in the unfilled state, and as a field label in the filled state. | `string`           | `''`        |
+| `maxLength`      | `max-length`      | The maximum string length for the input field.                                                                 | `number`           | `undefined` |
+| `value`          | `value`           | The value of the textarea.                                                                                     | `number \| string` | `''`        |
+| `width`          | `width`           | The maximum width for the input field.                                                                         | `number`           | `undefined` |
 
 
 ## Events
 
-| Event             | Description                                      | Type                  |
-| ----------------- | ------------------------------------------------ | --------------------- |
-| `textareaBlur`    | Event is fired when the form control loses focus | `CustomEvent<any>`    |
-| `textareaChanged` | Event is fired when the form control changes     | `CustomEvent<string>` |
+| Event             | Description                                      | Type                                     |
+| ----------------- | ------------------------------------------------ | ---------------------------------------- |
+| `admiraltyChange` | Event is fired when the form control changes     | `CustomEvent<TextAreaChangeEventDetail>` |
+| `textareaBlur`    | Event is fired when the form control loses focus | `CustomEvent<any>`                       |
 
 
 ## Dependencies

--- a/packages/core/src/components/textarea/textarea.interface.ts
+++ b/packages/core/src/components/textarea/textarea.interface.ts
@@ -1,0 +1,3 @@
+export interface TextAreaChangeEventDetail {
+  value: string | undefined | null;
+}

--- a/packages/core/src/components/textarea/textarea.spec.ts
+++ b/packages/core/src/components/textarea/textarea.spec.ts
@@ -21,7 +21,7 @@ describe('admiralty-textarea', () => {
           <admiralty-hint>
             Please enter description
           </admiralty-hint>
-          <textarea id="admiralty-textarea-${compId}"></textarea>
+          <textarea id="admiralty-textarea-${compId}" value=""></textarea>
         </div>
       </admiralty-textarea>
     `);
@@ -34,13 +34,13 @@ describe('admiralty-textarea', () => {
 
     const page = await newSpecPage({
       components: [TextareaComponent],
-      html: `<admiralty-textarea text="${testText}"></admiralty-textarea>`,
+      html: `<admiralty-textarea value="${testText}"></admiralty-textarea>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <admiralty-textarea text="${testText}">
+      <admiralty-textarea value="${testText}">
         <div class="text-area-container">
-          <textarea id="admiralty-textarea-${compId}">${testText}</textarea>
+          <textarea id="admiralty-textarea-${compId}" value="${testText}"></textarea>
         </div>
       </admiralty-textarea>
     `);
@@ -58,7 +58,7 @@ describe('admiralty-textarea', () => {
       <admiralty-textarea label="Description" disabled="true">
         <div class="text-area-container">
           <admiralty-label disabled="" for="admiralty-textarea-${compId}">Description</admiralty-label>
-          <textarea class="disabled" id="admiralty-textarea-${compId}"></textarea>
+          <textarea class="disabled" id="admiralty-textarea-${compId}" value=""></textarea>
         </div>
       </admiralty-textarea>
     `);
@@ -76,7 +76,7 @@ describe('admiralty-textarea', () => {
       <admiralty-textarea label="Description" invalid="true" invalidMessage="BAD">
         <div class="text-area-container">
           <admiralty-label for="admiralty-textarea-${compId}">Description</admiralty-label>
-          <textarea class="invalid" id="admiralty-textarea-${compId}"></textarea>
+          <textarea class="invalid" id="admiralty-textarea-${compId}" value=""></textarea>
           <admiralty-input-error></admiralty-input-error>
         </div>
       </admiralty-textarea>

--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -48,17 +48,17 @@ export const Invalid: Story = {
 };
 
 export const WithText: Story = {
-  render: args => html` <admiralty-textarea label="${args.label}" text="${args.text}"> </admiralty-textarea>`,
+  render: args => html` <admiralty-textarea label="${args.label}" text="${args.value}"> </admiralty-textarea>`,
   args: {
     label: 'With text',
-    text: 'Sample Text',
+    value: 'Sample Text',
   },
 };
 
 export const MaxLength: Story = {
-  render: args => html` <admiralty-textarea text="${args.text}" max-length="${args.maxLength}"> </admiralty-textarea>`,
+  render: args => html` <admiralty-textarea text="${args.value}" max-length="${args.maxLength}"> </admiralty-textarea>`,
   args: {
     maxLength: 1,
-    text: 'A',
+    value: 'A',
   },
 };

--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -48,7 +48,7 @@ export const Invalid: Story = {
 };
 
 export const WithText: Story = {
-  render: args => html` <admiralty-textarea label="${args.label}" text="${args.value}"> </admiralty-textarea>`,
+  render: args => html` <admiralty-textarea label="${args.label}" value="${args.value}"> </admiralty-textarea>`,
   args: {
     label: 'With text',
     value: 'Sample Text',
@@ -56,7 +56,7 @@ export const WithText: Story = {
 };
 
 export const MaxLength: Story = {
-  render: args => html` <admiralty-textarea text="${args.value}" max-length="${args.maxLength}"> </admiralty-textarea>`,
+  render: args => html` <admiralty-textarea value="${args.value}" max-length="${args.maxLength}"> </admiralty-textarea>`,
   args: {
     maxLength: 1,
     value: 'A',

--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -1,4 +1,5 @@
-import { Component, Host, h, Prop, Event, EventEmitter } from '@stencil/core';
+import { Component, Host, h, Prop, Event, EventEmitter, Watch } from '@stencil/core';
+import { TextAreaChangeEventDetail } from './textarea.interface';
 
 let textareaIds = 0;
 
@@ -10,15 +11,12 @@ let textareaIds = 0;
 export class TextareaComponent {
   private inputId = `admiralty-textarea-${textareaIds++}`;
 
+  private nativeTextArea?: HTMLTextAreaElement;
+
   /**
    * The label which will be used as a placeholder in the unfilled state, and as a field label in the filled state.
    */
   @Prop() label: string = '';
-
-  /**
-   * The contents of the textarea
-   */
-  @Prop() text: string = '';
 
   /**
    * The hint which will be used under the label to describe the input.
@@ -58,18 +56,45 @@ export class TextareaComponent {
 
   /**
    * Event is fired when the form control changes
-   * @event textareaChanged
+   * @event admiraltyChange
    */
-  @Event({ eventName: 'textareaChanged' }) textareaChanged: EventEmitter<string>;
+  @Event() admiraltyChange: EventEmitter<TextAreaChangeEventDetail>;
+
+  /**
+   * The value of the textarea.
+   */
+  @Prop({ mutable: true }) value?: string | number | null = '';
+
+  /**
+   * Update the native textarea element when the value changes
+   */
+  @Watch('value')
+  protected valueChanged() {
+    const nativeInput = this.nativeTextArea;
+    const value = this.getValue();
+    if (nativeInput && nativeInput.value !== value) {
+      nativeInput.value = value;
+    }
+    this.admiraltyChange.emit({ value: this.value == null ? this.getValue() : this.value.toString() });
+  }
 
   private onBlur = () => {
     this.textareaBlur.emit();
   };
 
-  private onChange = (_ev: any) => {
-    this.textareaChanged.emit(this.text);
+  private onInput = (ev: Event) => {
+    const input = ev.target as HTMLInputElement | null;
+    if (input) {
+      this.value = input.value || '';
+    }
   };
+
+  private getValue(): string {
+    return typeof this.value === 'number' ? this.value.toString() : (this.value || '').toString();
+  }
+
   render() {
+    const value = this.getValue();
     return (
       <Host>
         <div class="text-area-container">
@@ -80,15 +105,15 @@ export class TextareaComponent {
           ) : null}
           {this.hint ? <admiralty-hint disabled={this.disabled}>{this.hint}</admiralty-hint> : null}
           <textarea
+            ref={textArea => (this.nativeTextArea = textArea)}
             class={{ disabled: this.disabled, invalid: this.invalid }}
             style={this.width ? { maxWidth: `${this.width}px` } : {}}
             id={this.inputId}
-            maxlength={this.maxLength}
-            onChange={this.onChange}
+            value={value}
+            maxLength={this.maxLength}
+            onInput={this.onInput}
             onBlur={this.onBlur}
-          >
-            {this.text}
-          </textarea>
+          ></textarea>
           {this.invalid ? <admiralty-input-error>{this.invalidMessage}</admiralty-input-error> : null}
         </div>
       </Host>

--- a/packages/test-app/src/app/app.component.html
+++ b/packages/test-app/src/app/app.component.html
@@ -91,6 +91,7 @@
     <admiralty-radio name="radio1" value="radio2">Radio group label 2</admiralty-radio>
     <admiralty-radio name="radio1" value="radio3">Radio group label 3</admiralty-radio>
   </admiralty-radio-group>
+  <admiralty-textarea formControlName="textarea" label="Textarea Label"></admiralty-textarea>
   <admiralty-button type="submit">Submit</admiralty-button>
 </form>
 <admiralty-icon iconName="hippo"></admiralty-icon>
@@ -115,7 +116,7 @@
     (sideNavItemSelected)="onSideNavItemSelected($event)"
   ></admiralty-side-nav-item>
 </admiralty-side-nav>
-<admiralty-textarea label="Textarea Label" text="Some text"></admiralty-textarea>
+
 <admiralty-filter filterTitle="Awesome Filters">
   <admiralty-filter-group groupTitle="Group 1">
     <div style="display: flex; flex-direction: column">

--- a/packages/test-app/src/app/app.component.ts
+++ b/packages/test-app/src/app/app.component.ts
@@ -18,6 +18,7 @@ export class AppComponent {
     checkbox: new FormControl(true),
     radio: new FormControl(''),
     select: new FormControl('test1'),
+    textarea: new FormControl('This is a text area'),
   });
 
   blah = this.group.get('text');


### PR DESCRIPTION
Fixes: #78 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.3--canary.79.047a94a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.3.3--canary.79.047a94a.0
  npm install @ukho/admiralty-core@0.3.3--canary.79.047a94a.0
  # or 
  yarn add @ukho/admiralty-angular@0.3.3--canary.79.047a94a.0
  yarn add @ukho/admiralty-core@0.3.3--canary.79.047a94a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
