### PR TITLE
fix: admiralty type ahead item fails to append value on dynamic data

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -1626,7 +1626,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface AdmiraltyTypeAheadItem {
-        "value": string;
+        "value"?: string;
     }
     interface IntrinsicElements {
         "admiralty-breadcrumb": AdmiraltyBreadcrumb;

--- a/packages/core/src/components/type-ahead-item/readme.md
+++ b/packages/core/src/components/type-ahead-item/readme.md
@@ -7,9 +7,9 @@
 
 ## Properties
 
-| Property             | Attribute | Description | Type     | Default     |
-| -------------------- | --------- | ----------- | -------- | ----------- |
-| `value` _(required)_ | `value`   |             | `string` | `undefined` |
+| Property | Attribute | Description | Type     | Default     |
+| -------- | --------- | ----------- | -------- | ----------- |
+| `value`  | `value`   |             | `string` | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/core/src/components/type-ahead-item/type-ahead-item.tsx
+++ b/packages/core/src/components/type-ahead-item/type-ahead-item.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, Prop, Watch, h } from '@stencil/core';
+import { Component, Host, Prop, h } from '@stencil/core';
 
 @Component({
   tag: 'admiralty-type-ahead-item',
@@ -6,14 +6,9 @@ import { Component, Host, Prop, Watch, h } from '@stencil/core';
   scoped: true,
 })
 export class AdmiraltyTypeAheadItem {
-  @Prop() value!: string;
-
-  @Watch('value')
-  onNameChanged(value: string) {
-    console.log('got value: ', value);
-  }
+  @Prop() value: string;
 
   render() {
-    return <Host></Host>;
+    return <Host value={this.value}></Host>;
   }
 }

--- a/packages/core/src/components/type-ahead-item/type-ahead-item.tsx
+++ b/packages/core/src/components/type-ahead-item/type-ahead-item.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, Prop, h } from '@stencil/core';
+import { Component, Host, Prop, Watch, h } from '@stencil/core';
 
 @Component({
   tag: 'admiralty-type-ahead-item',
@@ -7,6 +7,11 @@ import { Component, Host, Prop, h } from '@stencil/core';
 })
 export class AdmiraltyTypeAheadItem {
   @Prop() value!: string;
+
+  @Watch('value')
+  onNameChanged(value: string) {
+    console.log('got value: ', value);
+  }
 
   render() {
     return <Host></Host>;

--- a/packages/core/src/components/type-ahead/test/type-ahead.spec.ts
+++ b/packages/core/src/components/type-ahead/test/type-ahead.spec.ts
@@ -2,6 +2,15 @@ import { newSpecPage } from '@stencil/core/testing';
 import { TypeAheadComponent } from '../type-ahead';
 import { AdmiraltyTypeAheadItem } from '../../type-ahead-item/type-ahead-item';
 
+const mutationObserverMock = jest.fn<MutationObserver, [MutationCallback]>().mockImplementation(() => {
+  return {
+    observe: jest.fn(),
+    disconnect: jest.fn(),
+    takeRecords: jest.fn(),
+  };
+});
+global.MutationObserver = mutationObserverMock;
+
 describe('type-ahead', () => {
   it('renders', async () => {
     const page = await newSpecPage({

--- a/packages/core/src/components/type-ahead/type-ahead.tsx
+++ b/packages/core/src/components/type-ahead/type-ahead.tsx
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Host, Prop, Event, h, State, Element } from '@stencil/core';
+import { Component, EventEmitter, Host, Prop, Event, h, State, Element, forceUpdate } from '@stencil/core';
 import { Keys } from '../Keys';
 
 @Component({
@@ -27,6 +27,8 @@ export class TypeAheadComponent {
   isSilenced = false;
   isAlternateStatusSection = false;
   statusText: string;
+
+  private mutation: MutationObserver;
 
   private originalSearch = '';
   private hasBeenFocusedAtLeastOnce = false;
@@ -75,17 +77,37 @@ export class TypeAheadComponent {
    */
   @Event() valueChanged: EventEmitter<string>;
 
-  connectedCallback() {
-    const slotItems = this.el.querySelectorAll('admiralty-type-ahead-item');
-    slotItems.forEach(el => {
-      this.filterList.push(el.getAttribute('value'));
-    });
-  }
-
   componentDidLoad() {
     if (this.value) {
       this.inputValue = this.value;
     }
+  }
+
+  connectedCallback() {
+    this.mutation = new MutationObserver(() => {
+      this.populateFilterList();
+      forceUpdate(this);
+    });
+    this.mutation.observe(this.el, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  disconnectedCallback() {
+    if (this.mutation) {
+      this.mutation.disconnect();
+      this.mutation = undefined;
+    }
+  }
+
+  populateFilterList() {
+    const slotItems = this.el.querySelectorAll('admiralty-type-ahead-item');
+    this.filterList = [];
+    slotItems.forEach(el => {
+      this.filterList.push(el.getAttribute('value'));
+      console.log('fliterlist value ', el.getAttribute('value'));
+    });
   }
 
   handleFocusIn() {

--- a/packages/test-app/src/app/app.component.html
+++ b/packages/test-app/src/app/app.component.html
@@ -148,6 +148,8 @@
   <admiralty-type-ahead-item value="guinea pig"></admiralty-type-ahead-item>
 </admiralty-type-ahead>
 
+<admiralty-button (click)="typeahead()">Button</admiralty-button>
+
 <ng-container *ngFor="let item of commissioningOrganisations">
   <span>{{ item.organisationName }}</span>
 </ng-container>

--- a/packages/test-app/src/app/app.component.html
+++ b/packages/test-app/src/app/app.component.html
@@ -148,6 +148,20 @@
   <admiralty-type-ahead-item value="guinea pig"></admiralty-type-ahead-item>
 </admiralty-type-ahead>
 
+<ng-container *ngFor="let item of commissioningOrganisations">
+  <span>{{ item.organisationName }}</span>
+</ng-container>
+
+<admiralty-type-ahead resultsOnInitFocus="true" type="text" [label]="'Commissioning organisation *'">
+  <admiralty-type-ahead-item value="ostrich"></admiralty-type-ahead-item>
+  <ng-template ngFor let-hero let-i="index" [ngForOf]="commissioningOrganisations">
+    <admiralty-type-ahead-item [value]="hero.organisationName"></admiralty-type-ahead-item>
+  </ng-template>
+  <admiralty-type-ahead-item [value]="commissioningOrganisations[0].organisationName"></admiralty-type-ahead-item>
+  <admiralty-type-ahead-item value="{{ commissioningOrganisations[0].organisationName }}"></admiralty-type-ahead-item>
+  <admiralty-type-ahead-item value="guinea pig"></admiralty-type-ahead-item>
+</admiralty-type-ahead>
+
 <admiralty-table caption="Favourite Foods">
   <admiralty-table-header>
     <admiralty-table-header-cell>Name</admiralty-table-header-cell>
@@ -197,3 +211,4 @@
   your nationality, you’ll have to send copies of identity documents through the post.
 </admiralty-read-more>
 <br />
+

--- a/packages/test-app/src/app/app.component.html
+++ b/packages/test-app/src/app/app.component.html
@@ -156,11 +156,10 @@
 
 <admiralty-type-ahead resultsOnInitFocus="true" type="text" [label]="'Commissioning organisation *'">
   <admiralty-type-ahead-item value="ostrich"></admiralty-type-ahead-item>
-  <ng-template ngFor let-hero let-i="index" [ngForOf]="commissioningOrganisations">
-    <admiralty-type-ahead-item [value]="hero.organisationName"></admiralty-type-ahead-item>
-  </ng-template>
-  <admiralty-type-ahead-item [value]="commissioningOrganisations[0].organisationName"></admiralty-type-ahead-item>
-  <admiralty-type-ahead-item value="{{ commissioningOrganisations[0].organisationName }}"></admiralty-type-ahead-item>
+  <admiralty-type-ahead-item
+    *ngFor="let item of commissioningOrganisations"
+    [value]="item.organisationName"
+  ></admiralty-type-ahead-item>
   <admiralty-type-ahead-item value="guinea pig"></admiralty-type-ahead-item>
 </admiralty-type-ahead>
 

--- a/packages/test-app/src/app/app.component.ts
+++ b/packages/test-app/src/app/app.component.ts
@@ -46,6 +46,11 @@ export class AppComponent {
     });
   }
 
+  typeahead() {
+    console.log('gregtest');
+    this.commissioningOrganisations = [{ id: 6, organisationName: '7' }];
+  }
+
   commissioningOrganisations: CommissioningOrganisation[] = [{ id: 9, organisationName: '8' }];
 }
 

--- a/packages/test-app/src/app/app.component.ts
+++ b/packages/test-app/src/app/app.component.ts
@@ -2,6 +2,12 @@ import { Component } from '@angular/core';
 import { QueryList, ViewChildren } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { AdmiraltySideNavItem } from '@ukho/admiralty-angular';
+import { Observable } from 'rxjs';
+
+export interface CommissioningOrganisation {
+  id?: number;
+  organisationName?: string;
+}
 
 @Component({
   selector: 'app-root',
@@ -39,4 +45,7 @@ export class AppComponent {
       sideNavItem.navActive = sideNavItem.sideNavItemId === sideNavItemId;
     });
   }
+
+  commissioningOrganisations: CommissioningOrganisation[] = [{ id: 9, organisationName: '8' }];
 }
+

--- a/packages/test-app/src/app/app.component.ts
+++ b/packages/test-app/src/app/app.component.ts
@@ -48,9 +48,12 @@ export class AppComponent {
 
   typeahead() {
     console.log('gregtest');
-    this.commissioningOrganisations = [{ id: 6, organisationName: '7' }];
+    this.commissioningOrganisations = [{ id: 6, organisationName: 'third organisation name' }];
   }
 
-  commissioningOrganisations: CommissioningOrganisation[] = [{ id: 9, organisationName: '8' }];
+  commissioningOrganisations: CommissioningOrganisation[] = [
+    { id: 9, organisationName: 'first organisation name' },
+    { id: 10, organisationName: 'second organisation name' },
+  ];
 }
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.4--canary.80.acfa172.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.3.4--canary.80.acfa172.0
  npm install @ukho/admiralty-core@0.3.4--canary.80.acfa172.0
  # or 
  yarn add @ukho/admiralty-angular@0.3.4--canary.80.acfa172.0
  yarn add @ukho/admiralty-core@0.3.4--canary.80.acfa172.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
