### PR TITLE
fix: input component invalid error message layout space not reserved when not displayed

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,6 +38,12 @@
 				"dbaeumer.vscode-eslint"
 			]
 		}
+  },
+
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
 	}
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/packages/core/src/components/input/input.spec.ts
+++ b/packages/core/src/components/input/input.spec.ts
@@ -11,10 +11,12 @@ describe('admiralty-input', () => {
       <admiralty-input>
         <div class="text-input-container">
           <input autocomplete="off" id="admiralty-input-1" name="admiralty-input-1" type="text" value="">
+          <admiralty-input-error style="visibility: hidden;"></admiralty-input-error>
         </div>
       </admiralty-input>
     `);
   });
+
   it('renders with a label', async () => {
     const page = await newSpecPage({
       components: [InputComponent],
@@ -25,6 +27,7 @@ describe('admiralty-input', () => {
         <div class="text-input-container">
           <admiralty-label for="admiralty-input-2">test-label</admiralty-label>
           <input autocomplete="off" id="admiralty-input-2" name="admiralty-input-2" type="text" value="">
+          <admiralty-input-error style="visibility: hidden;"></admiralty-input-error>
         </div>
       </admiralty-input>
     `);
@@ -39,6 +42,37 @@ describe('admiralty-input', () => {
       <admiralty-input disabled>
         <div class="text-input-container">
           <input disabled autocomplete="off" class="disabled" id="admiralty-input-3" name="admiralty-input-3" type="text" value="">
+          <admiralty-input-error style="visibility: hidden;"></admiralty-input-error>
+        </div>
+      </admiralty-input>
+    `);
+  });
+
+  it('renders invalid even without invalidMessage', async () => {
+    const page = await newSpecPage({
+      components: [InputComponent],
+      html: `<admiralty-input invalid="true"></admiralty-input>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <admiralty-input invalid="true">
+        <div class="text-input-container">
+          <input autocomplete="off" class="invalid" id="admiralty-input-4" name="admiralty-input-4" type="text" value="">
+          <admiralty-input-error style="visibility: visible;"></admiralty-input-error>
+        </div>
+      </admiralty-input>
+    `);
+  });
+
+  it('renders invalid with invalidMessage', async () => {
+    const page = await newSpecPage({
+      components: [InputComponent],
+      html: `<admiralty-input invalid="true" invalidMessage="This is invalid!"></admiralty-input>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <admiralty-input invalid="true" invalidMessage="This is invalid!">
+        <div class="text-input-container">
+          <input autocomplete="off" class="invalid" id="admiralty-input-5" name="admiralty-input-5" type="text" value="">
+          <admiralty-input-error style="visibility: visible;"></admiralty-input-error>
         </div>
       </admiralty-input>
     `);
@@ -52,7 +86,8 @@ describe('admiralty-input', () => {
     expect(page.root).toEqualHtml(`
       <admiralty-input type="date">
         <div class="text-input-container">
-          <input type="date" autocomplete="off" id="admiralty-input-4" name="admiralty-input-4" value="">
+          <input type="date" autocomplete="off" id="admiralty-input-6" name="admiralty-input-6" value="">
+          <admiralty-input-error style="visibility: hidden;"></admiralty-input-error>
         </div>
       </admiralty-input>
     `);

--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -133,7 +133,7 @@ export class InputComponent implements ComponentInterface {
             maxWidth: this.width ? `${this.width}px` : null,
           }}
         />
-        {this.invalid ? <admiralty-input-error>{this.invalidMessage}</admiralty-input-error> : null}
+        <admiralty-input-error style={{ visibility: this.invalid ? 'visible' : 'hidden' }}>{this.invalidMessage}</admiralty-input-error>
       </div>
     );
   }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.5--canary.82.b10cedb.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.3.5--canary.82.b10cedb.0
  npm install @ukho/admiralty-core@0.3.5--canary.82.b10cedb.0
  # or 
  yarn add @ukho/admiralty-angular@0.3.5--canary.82.b10cedb.0
  yarn add @ukho/admiralty-core@0.3.5--canary.82.b10cedb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
