### PR TITLE
fix: progress bar colours in Firefox

### DIFF
--- a/packages/core/src/components/progress-bar/progress-bar.scss
+++ b/packages/core/src/components/progress-bar/progress-bar.scss
@@ -1,4 +1,4 @@
-@use "../../scss/vars/colours" as colours;
+@use '../../scss/vars/colours' as colours;
 
 progress {
   appearance: none;
@@ -12,11 +12,13 @@ progress {
   height: 1em;
   width: 100%;
 
-  &[value].error::-webkit-progress-value {
+  &[value].error::-webkit-progress-value,
+  &[value].error::-moz-progress-bar {
     background-color: colours.$colour-utility-error;
   }
 
-  &[value]::-webkit-progress-value {
+  &[value]::-webkit-progress-value,
+  &[value]::-moz-progress-bar {
     background-color: colours.$colour-utility-success;
   }
 }

--- a/packages/core/src/components/progress-bar/progress-bar.scss
+++ b/packages/core/src/components/progress-bar/progress-bar.scss
@@ -12,12 +12,18 @@ progress {
   height: 1em;
   width: 100%;
 
-  &[value].error::-webkit-progress-value,
+  &[value].error::-webkit-progress-value {
+    background-color: colours.$colour-utility-error;
+  }
+
   &[value].error::-moz-progress-bar {
     background-color: colours.$colour-utility-error;
   }
 
-  &[value]::-webkit-progress-value,
+  &[value]::-webkit-progress-value {
+    background-color: colours.$colour-utility-success;
+  }
+
   &[value]::-moz-progress-bar {
     background-color: colours.$colour-utility-success;
   }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.7--canary.83.50cb2cc.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.3.7--canary.83.50cb2cc.0
  npm install @ukho/admiralty-core@0.3.7--canary.83.50cb2cc.0
  # or 
  yarn add @ukho/admiralty-angular@0.3.7--canary.83.50cb2cc.0
  yarn add @ukho/admiralty-core@0.3.7--canary.83.50cb2cc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
