### PR TITLE
fix: Typeahead drawer positioning

### DIFF
--- a/packages/core/src/components/type-ahead/type-ahead.scss
+++ b/packages/core/src/components/type-ahead/type-ahead.scss
@@ -17,19 +17,20 @@
 
 .typeahead-list-container {
   position: relative;
-  left: 0px;
-  top: -24px;
-  background-color: colours.$colour-white;
-  width: 100%;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  border: 2px solid colours.$colour-text;
-  border-top: none;
-  box-sizing: border-box;
-  max-height: 180px;
-  overflow-y: auto;
-  z-index: 1;
 
   .typeahead-list {
+    position: absolute;
+    left: 0px;
+    top: -24px;
+    background-color: colours.$colour-white;
+    width: 100%;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    border: 2px solid colours.$colour-text;
+    border-top: none;
+    box-sizing: border-box;
+    max-height: 180px;
+    overflow-y: auto;
+    z-index: 1;
     list-style: none;
 
     li {

--- a/packages/core/src/components/type-ahead/type-ahead.scss
+++ b/packages/core/src/components/type-ahead/type-ahead.scss
@@ -1,6 +1,6 @@
-@use "../../scss/vars/colours";
-@use "../../scss/base/a11y";
-@use "../../scss/base/typography";
+@use '../../scss/vars/colours';
+@use '../../scss/base/a11y';
+@use '../../scss/base/typography';
 
 * {
   margin: 0px;
@@ -18,6 +18,7 @@
 .typeahead-list-container {
   position: relative;
   left: 0px;
+  top: -24px;
   background-color: colours.$colour-white;
   width: 100%;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
@@ -49,4 +50,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Fixes #84 
Fixes #81 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.6--canary.85.53b5461.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.3.6--canary.85.53b5461.0
  npm install @ukho/admiralty-core@0.3.6--canary.85.53b5461.0
  # or 
  yarn add @ukho/admiralty-angular@0.3.6--canary.85.53b5461.0
  yarn add @ukho/admiralty-core@0.3.6--canary.85.53b5461.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
