### PR TITLE
fix: admiralty input validation displays exclamation mark when invalid message is not provided

### DIFF
--- a/packages/core/src/components/input/input.spec.ts
+++ b/packages/core/src/components/input/input.spec.ts
@@ -57,7 +57,7 @@ describe('admiralty-input', () => {
       <admiralty-input invalid="true">
         <div class="text-input-container">
           <input autocomplete="off" class="invalid" id="admiralty-input-4" name="admiralty-input-4" type="text" value="">
-          <admiralty-input-error style="visibility: visible;"></admiralty-input-error>
+          <admiralty-input-error style="visibility: hidden;"></admiralty-input-error>
         </div>
       </admiralty-input>
     `);
@@ -66,13 +66,15 @@ describe('admiralty-input', () => {
   it('renders invalid with invalidMessage', async () => {
     const page = await newSpecPage({
       components: [InputComponent],
-      html: `<admiralty-input invalid="true" invalidMessage="This is invalid!"></admiralty-input>`,
+      html: `<admiralty-input invalid="true" invalid-message="This is invalid!"></admiralty-input>`,
     });
     expect(page.root).toEqualHtml(`
-      <admiralty-input invalid="true" invalidMessage="This is invalid!">
+      <admiralty-input invalid="true" invalid-message="This is invalid!">
         <div class="text-input-container">
           <input autocomplete="off" class="invalid" id="admiralty-input-5" name="admiralty-input-5" type="text" value="">
-          <admiralty-input-error style="visibility: visible;"></admiralty-input-error>
+          <admiralty-input-error style="visibility: visible;">
+            This is invalid!
+          </admiralty-input-error>
         </div>
       </admiralty-input>
     `);

--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -139,7 +139,7 @@ export class InputComponent implements ComponentInterface {
             maxWidth: this.width ? `${this.width}px` : null,
           }}
         />
-        <admiralty-input-error style={{ visibility: this.invalid ? 'visible' : 'hidden' }}>{this.invalidMessage}</admiralty-input-error>
+        <admiralty-input-error style={{ visibility: this.invalid && this.invalidMessage ? 'visible' : 'hidden' }}>{this.invalidMessage}</admiralty-input-error>
       </div>
     );
   }

--- a/packages/core/src/components/textarea/textarea.spec.ts
+++ b/packages/core/src/components/textarea/textarea.spec.ts
@@ -69,15 +69,35 @@ describe('admiralty-textarea', () => {
 
     const page = await newSpecPage({
       components: [TextareaComponent],
-      html: `<admiralty-textarea label="Description" invalid="true" invalidMessage="BAD"></admiralty-textarea>`,
+      html: `<admiralty-textarea label="Description" invalid="true" invalid-message="BAD"></admiralty-textarea>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <admiralty-textarea label="Description" invalid="true" invalidMessage="BAD">
+      <admiralty-textarea label="Description" invalid="true" invalid-message="BAD">
         <div class="text-area-container">
           <admiralty-label for="admiralty-textarea-${compId}">Description</admiralty-label>
           <textarea class="invalid" id="admiralty-textarea-${compId}" value=""></textarea>
-          <admiralty-input-error></admiralty-input-error>
+          <admiralty-input-error>
+            BAD
+          </admiralty-input-error>
+        </div>
+      </admiralty-textarea>
+    `);
+  });
+
+  it('should not show admiralty-input-error when invalid but no message provided', async () => {
+    ++compId;
+
+    const page = await newSpecPage({
+      components: [TextareaComponent],
+      html: `<admiralty-textarea label="Description" invalid="true" invalidMessage=""></admiralty-textarea>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <admiralty-textarea label="Description" invalid="true" invalidMessage="">
+        <div class="text-area-container">
+          <admiralty-label for="admiralty-textarea-${compId}">Description</admiralty-label>
+          <textarea class="invalid" id="admiralty-textarea-${compId}" value=""></textarea>
         </div>
       </admiralty-textarea>
     `);

--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -114,7 +114,7 @@ export class TextareaComponent {
             onInput={this.onInput}
             onBlur={this.onBlur}
           ></textarea>
-          {this.invalid ? <admiralty-input-error>{this.invalidMessage}</admiralty-input-error> : null}
+          {this.invalid && this.invalidMessage ? <admiralty-input-error>{this.invalidMessage}</admiralty-input-error> : null}
         </div>
       </Host>
     );


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.2--canary.101.582f0bd.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.4.2--canary.101.582f0bd.0
  npm install @ukho/admiralty-core@0.4.2--canary.101.582f0bd.0
  # or 
  yarn add @ukho/admiralty-angular@0.4.2--canary.101.582f0bd.0
  yarn add @ukho/admiralty-core@0.4.2--canary.101.582f0bd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
