### PR TITLE
Fix: Input and Radio Group event names clashing

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -514,7 +514,7 @@ export class AdmiraltyInput {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['admiraltyChange']);
+    proxyOutputs(this, this.el, ['admiraltyInput']);
   }
 }
 
@@ -525,7 +525,7 @@ export declare interface AdmiraltyInput extends Components.AdmiraltyInput {
   /**
    * Emitted when the value has changed.
    */
-  admiraltyChange: EventEmitter<CustomEvent<IAdmiraltyInputInputChangeEventDetail>>;
+  admiraltyInput: EventEmitter<CustomEvent<IAdmiraltyInputInputChangeEventDetail>>;
 }
 
 

--- a/packages/angular/src/lib/stencil-generated/number-value-accessor.ts
+++ b/packages/angular/src/lib/stencil-generated/number-value-accessor.ts
@@ -7,7 +7,7 @@ import { ValueAccessor } from './value-accessor';
   /* tslint:disable-next-line:directive-selector */
   selector: 'admiralty-input[type=number]',
   host: {
-    '(admiraltyChange)': 'handleChangeEvent($event.target.value)'
+    '(admiraltyInput)': 'handleChangeEvent($event.target.value)'
   },
   providers: [
     {

--- a/packages/angular/src/lib/stencil-generated/text-value-accessor.ts
+++ b/packages/angular/src/lib/stencil-generated/text-value-accessor.ts
@@ -7,7 +7,7 @@ import { ValueAccessor } from './value-accessor';
   /* tslint:disable-next-line:directive-selector */
   selector: 'admiralty-input:not([type=number]), admiralty-textarea',
   host: {
-    '(admiraltyChange)': 'handleChangeEvent($event.target.value)'
+    '(admiraltyInput)': 'handleChangeEvent($event.target.value)'
   },
   providers: [
     {

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -1304,7 +1304,7 @@ declare namespace LocalJSX {
         /**
           * Emitted when the value has changed.
          */
-        "onAdmiraltyChange"?: (event: AdmiraltyInputCustomEvent<InputChangeEventDetail>) => void;
+        "onAdmiraltyInput"?: (event: AdmiraltyInputCustomEvent<InputChangeEventDetail>) => void;
         /**
           * The placeholder text to show in the input
          */

--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -86,7 +86,7 @@ export class InputComponent implements ComponentInterface {
   /**
    * Emitted when the value has changed.
    */
-  @Event() admiraltyChange: EventEmitter<InputChangeEventDetail>;
+  @Event() admiraltyInput: EventEmitter<InputChangeEventDetail>;
 
   /**
    * Update the native input element when the value changes
@@ -98,7 +98,7 @@ export class InputComponent implements ComponentInterface {
     if (nativeInput && nativeInput.value !== value) {
       nativeInput.value = value;
     }
-    this.admiraltyChange.emit({ value: this.value == null ? this.getValue() : this.value.toString() });
+    this.admiraltyInput.emit({ value: this.value == null ? this.getValue() : this.value.toString() });
   }
 
   private onInput = (ev: Event) => {

--- a/packages/core/src/components/input/readme.md
+++ b/packages/core/src/components/input/readme.md
@@ -33,9 +33,9 @@ and checkbox.
 
 ## Events
 
-| Event             | Description                         | Type                                  |
-| ----------------- | ----------------------------------- | ------------------------------------- |
-| `admiraltyChange` | Emitted when the value has changed. | `CustomEvent<InputChangeEventDetail>` |
+| Event            | Description                         | Type                                  |
+| ---------------- | ----------------------------------- | ------------------------------------- |
+| `admiraltyInput` | Emitted when the value has changed. | `CustomEvent<InputChangeEventDetail>` |
 
 
 ## Dependencies

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -5,7 +5,7 @@ import { angularOutputTarget as angular, ValueAccessorConfig } from '@stencil/an
 const angularValueAccessorBindings: ValueAccessorConfig[] = [
   {
     elementSelectors: ['admiralty-input:not([type=number])', 'admiralty-textarea'],
-    event: 'admiraltyChange',
+    event: 'admiraltyInput',
     targetAttr: 'value',
     type: 'text',
   },
@@ -29,7 +29,7 @@ const angularValueAccessorBindings: ValueAccessorConfig[] = [
   },
   {
     elementSelectors: ['admiralty-input[type=number]'],
-    event: 'admiraltyChange',
+    event: 'admiraltyInput',
     targetAttr: 'value',
     type: 'number',
   },


### PR DESCRIPTION
switching admiralty-input to emit 'admiraltyInput' rather than 'admiraltyChange'

Fixes: #95 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.3--canary.103.091eddf.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.4.3--canary.103.091eddf.0
  npm install @ukho/admiralty-core@0.4.3--canary.103.091eddf.0
  # or 
  yarn add @ukho/admiralty-angular@0.4.3--canary.103.091eddf.0
  yarn add @ukho/admiralty-core@0.4.3--canary.103.091eddf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
