### PR TITLE
Fixing the text area event name change that was forgotten

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -1035,7 +1035,7 @@ export class AdmiraltyTextarea {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['textareaBlur', 'admiraltyChange']);
+    proxyOutputs(this, this.el, ['textareaBlur', 'admiraltyInput']);
   }
 }
 
@@ -1050,7 +1050,7 @@ export declare interface AdmiraltyTextarea extends Components.AdmiraltyTextarea 
   /**
    * Event is fired when the form control changes @event admiraltyChange
    */
-  admiraltyChange: EventEmitter<CustomEvent<IAdmiraltyTextareaTextAreaChangeEventDetail>>;
+  admiraltyInput: EventEmitter<CustomEvent<IAdmiraltyTextareaTextAreaChangeEventDetail>>;
 }
 
 

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -1592,7 +1592,7 @@ declare namespace LocalJSX {
           * Event is fired when the form control changes
           * @event admiraltyChange
          */
-        "onAdmiraltyChange"?: (event: AdmiraltyTextareaCustomEvent<TextAreaChangeEventDetail>) => void;
+        "onAdmiraltyInput"?: (event: AdmiraltyTextareaCustomEvent<TextAreaChangeEventDetail>) => void;
         /**
           * Event is fired when the form control loses focus
           * @event textareaBlur

--- a/packages/core/src/components/textarea/readme.md
+++ b/packages/core/src/components/textarea/readme.md
@@ -21,10 +21,10 @@
 
 ## Events
 
-| Event             | Description                                      | Type                                     |
-| ----------------- | ------------------------------------------------ | ---------------------------------------- |
-| `admiraltyChange` | Event is fired when the form control changes     | `CustomEvent<TextAreaChangeEventDetail>` |
-| `textareaBlur`    | Event is fired when the form control loses focus | `CustomEvent<any>`                       |
+| Event            | Description                                      | Type                                     |
+| ---------------- | ------------------------------------------------ | ---------------------------------------- |
+| `admiraltyInput` | Event is fired when the form control changes     | `CustomEvent<TextAreaChangeEventDetail>` |
+| `textareaBlur`   | Event is fired when the form control loses focus | `CustomEvent<any>`                       |
 
 
 ## Dependencies

--- a/packages/core/src/components/textarea/textarea.tsx
+++ b/packages/core/src/components/textarea/textarea.tsx
@@ -58,7 +58,7 @@ export class TextareaComponent {
    * Event is fired when the form control changes
    * @event admiraltyChange
    */
-  @Event() admiraltyChange: EventEmitter<TextAreaChangeEventDetail>;
+  @Event() admiraltyInput: EventEmitter<TextAreaChangeEventDetail>;
 
   /**
    * The value of the textarea.
@@ -75,7 +75,7 @@ export class TextareaComponent {
     if (nativeInput && nativeInput.value !== value) {
       nativeInput.value = value;
     }
-    this.admiraltyChange.emit({ value: this.value == null ? this.getValue() : this.value.toString() });
+    this.admiraltyInput.emit({ value: this.value == null ? this.getValue() : this.value.toString() });
   }
 
   private onBlur = () => {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.4--canary.104.a73ac95.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.4.4--canary.104.a73ac95.0
  npm install @ukho/admiralty-core@0.4.4--canary.104.a73ac95.0
  # or 
  yarn add @ukho/admiralty-angular@0.4.4--canary.104.a73ac95.0
  yarn add @ukho/admiralty-core@0.4.4--canary.104.a73ac95.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
