### PR TITLE
Fixing the radio component hit detection

### DIFF
--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -29,7 +29,6 @@ export class RadioGroupComponent implements ComponentInterface {
   @Watch('value')
   valueChanged(value: any) {
     this.setRadioTabindex(value);
-
     this.admiraltyChange.emit({ value });
   }
 

--- a/packages/core/src/components/radio/radio.tsx
+++ b/packages/core/src/components/radio/radio.tsx
@@ -69,6 +69,15 @@ export class RadioComponent {
 
     if (radioGroup) {
       this.updateState();
+      radioGroup.addEventListener('admiraltyChange', this.updateState);
+    }
+  }
+
+  disconnectedCallback() {
+    const radioGroup = this.radioGroup;
+    if (radioGroup) {
+      radioGroup.removeEventListener('admiraltyChange', this.updateState);
+      this.radioGroup = null;
     }
   }
 
@@ -81,6 +90,9 @@ export class RadioComponent {
   private updateState = () => {
     if (this.radioGroup) {
       this.checked = this.radioGroup.value === this.value;
+      if (this.nativeInput && this.checked) {
+        this.nativeInput.focus();
+      }
     }
   };
 


### PR DESCRIPTION
The radio buttons will now correctly show when you click between the label and the dot

Fixes: #61 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.5--canary.105.a14b51d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.4.5--canary.105.a14b51d.0
  npm install @ukho/admiralty-core@0.4.5--canary.105.a14b51d.0
  # or 
  yarn add @ukho/admiralty-angular@0.4.5--canary.105.a14b51d.0
  yarn add @ukho/admiralty-core@0.4.5--canary.105.a14b51d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
