### PR TITLE
feat: Remove admiralty-file-input label update behaviour when files are selected

### DIFF
--- a/packages/core/src/components/file-input/file-input.scss
+++ b/packages/core/src/components/file-input/file-input.scss
@@ -43,13 +43,9 @@ label {
     color: colours.$colour-admiralty-blue;
     flex: 0 1;
     font-size: 18px;
-    font-weight: typography.$font-weight-light;
+    font-weight: typography.$font-weight-medium;
     text-align: center;
     margin: 0.4rem 0;
-
-    &.instructions {
-      font-weight: typography.$font-weight-medium;
-    }
   }
 }
 

--- a/packages/core/src/components/file-input/file-input.scss
+++ b/packages/core/src/components/file-input/file-input.scss
@@ -1,11 +1,11 @@
-@use "../../scss/vars/colours";
-@use "../../scss/vars/typography";
+@use '../../scss/vars/colours';
+@use '../../scss/vars/typography';
 
 .admiralty-file-input {
   background: #eee;
   display: flex;
   position: relative;
-  border: 2px dashed colours.$colour-admiralty-blue;;
+  border: 2px dashed colours.$colour-admiralty-blue;
   min-height: 120px;
   align-content: stretch;
   justify-content: stretch;
@@ -15,7 +15,8 @@
   line-height: 24px;
   font-weight: 300;
 
-  &.drop_zone { // active when file is dragged over label
+  &.drop_zone {
+    // active when file is dragged over label
     background: #fff !important;
   }
 
@@ -23,7 +24,7 @@
     color: colours.$colour-admiralty-blue;
     font-size: 24px;
     font-weight: 900;
-    margin: .4rem auto;
+    margin: 0.4rem auto;
     text-align: center;
     flex: 0 1;
   }
@@ -35,7 +36,7 @@ label {
   display: flex;
   align-content: center;
   flex-direction: column;
-  flex:1;
+  flex: 1;
   justify-content: center;
   cursor: pointer;
 
@@ -49,7 +50,7 @@ label {
   }
 }
 
-input[type=file] {
+input[type='file'] {
   align-items: baseline;
   overflow: visible;
   position: absolute;

--- a/packages/core/src/components/file-input/file-input.spec.ts
+++ b/packages/core/src/components/file-input/file-input.spec.ts
@@ -12,7 +12,7 @@ describe('file-input', () => {
         <div class="admiralty-file-input">
           <label htmlfor="admiralty-file-input-1">
             <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
-            <span class="instructions">
+            <span>
               Click to choose a file or drag it
             </span>
           </label>
@@ -32,7 +32,7 @@ describe('file-input', () => {
         <div class="admiralty-file-input">
           <label htmlfor="admiralty-file-input-2">
             <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
-            <span class="instructions">
+            <span>
               Click to choose a file or drag it
             </span>
           </label>
@@ -52,7 +52,7 @@ describe('file-input', () => {
         <div class="admiralty-file-input">
           <label htmlfor="admiralty-file-input-3">
             <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
-            <span class="instructions">
+            <span>
               Click to choose a file or drag it
             </span>
           </label>
@@ -72,7 +72,7 @@ describe('file-input', () => {
         <div class="admiralty-file-input">
           <label htmlfor="admiralty-file-input-4">
             <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
-            <span class="instructions">
+            <span>
               My other label
             </span>
           </label>

--- a/packages/core/src/components/file-input/file-input.tsx
+++ b/packages/core/src/components/file-input/file-input.tsx
@@ -84,10 +84,6 @@ export class FileInputComponent {
     }
   }
 
-  get filesDisplay() {
-    return `${this.files[0].name} (${this.sizeOf(this.files[0].size)}) ${this.files.length > 1 ? ' ...' : ''}`;
-  }
-
   /**
    * Takes the bytes of a file and returns it as human readable figure
    * @param bytes pass bytes throughs as a number
@@ -107,7 +103,7 @@ export class FileInputComponent {
         <div class="admiralty-file-input">
           <label htmlFor={this.id}>
             <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
-            {this.files?.length ? <span>{this.filesDisplay}</span> : <span class="instructions">{this.label}</span>}
+            <span>{this.label}</span>
           </label>
           <input
             onChange={event => this.changeHandler(event)}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.0--canary.120.fd724b8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.6.0--canary.120.fd724b8.0
  npm install @ukho/admiralty-core@0.6.0--canary.120.fd724b8.0
  # or 
  yarn add @ukho/admiralty-angular@0.6.0--canary.120.fd724b8.0
  yarn add @ukho/admiralty-core@0.6.0--canary.120.fd724b8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
