### PR TITLE
feat: Add invalid and invalidMessage to File Input and remove layout bottom margin

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -205,14 +205,14 @@ export declare interface AdmiraltyExpansion extends Components.AdmiraltyExpansio
 
 
 @ProxyCmp({
-  inputs: ['label', 'multiple']
+  inputs: ['invalid', 'invalidMessage', 'label', 'multiple']
 })
 @Component({
   selector: 'admiralty-file-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['label', 'multiple'],
+  inputs: ['invalid', 'invalidMessage', 'label', 'multiple'],
 })
 export class AdmiraltyFileInput {
   protected el: HTMLElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -143,6 +143,14 @@ export namespace Components {
     }
     interface AdmiraltyFileInput {
         /**
+          * Whether to show that the file input is in an invalid state.
+         */
+        "invalid": boolean;
+        /**
+          * The message to show when the file input is invalid.
+         */
+        "invalidMessage": string;
+        /**
           * Used to display instructions to the user and is replaced with the filename the user inputs
          */
         "label": string;
@@ -1133,6 +1141,14 @@ declare namespace LocalJSX {
         "onToggled"?: (event: AdmiraltyExpansionCustomEvent<boolean>) => void;
     }
     interface AdmiraltyFileInput {
+        /**
+          * Whether to show that the file input is in an invalid state.
+         */
+        "invalid"?: boolean;
+        /**
+          * The message to show when the file input is invalid.
+         */
+        "invalidMessage"?: string;
         /**
           * Used to display instructions to the user and is replaced with the filename the user inputs
          */

--- a/packages/core/src/components/file-input/file-input.scss
+++ b/packages/core/src/components/file-input/file-input.scss
@@ -9,7 +9,7 @@
   min-height: 120px;
   align-content: stretch;
   justify-content: stretch;
-  margin-bottom: 36px;
+  margin-bottom: 6px;
   font-family: typography.$font-family;
   font-size: 18px;
   line-height: 24px;

--- a/packages/core/src/components/file-input/file-input.spec.ts
+++ b/packages/core/src/components/file-input/file-input.spec.ts
@@ -18,6 +18,7 @@ describe('file-input', () => {
           </label>
           <input aria-hidden="true" aria-label="File Upload" class="admiralty-form-field" id="admiralty-file-input-1" type="file">
         </div>
+        <admiralty-input-invalid style="visibility: hidden;"></admiralty-input-invalid>
       </admiralty-file-input>
     `);
   });
@@ -38,6 +39,7 @@ describe('file-input', () => {
           </label>
           <input aria-hidden="true" aria-label="File Upload" class="admiralty-form-field" id="admiralty-file-input-2" multiple="" type="file">
         </div>
+        <admiralty-input-invalid style="visibility: hidden;"></admiralty-input-invalid>
       </admiralty-file-input>
     `);
   });
@@ -58,6 +60,7 @@ describe('file-input', () => {
           </label>
           <input aria-hidden="true" aria-label="File Upload" class="admiralty-form-field" id="admiralty-file-input-3" type="file">
         </div>
+        <admiralty-input-invalid style="visibility: hidden;"></admiralty-input-invalid>
       </admiralty-file-input>
     `);
   });
@@ -78,6 +81,51 @@ describe('file-input', () => {
           </label>
           <input aria-hidden="true" aria-label="File Upload" class="admiralty-form-field" id="admiralty-file-input-4" type="file">
         </div>
+        <admiralty-input-invalid style="visibility: hidden;"></admiralty-input-invalid>
+      </admiralty-file-input>
+    `);
+  });
+
+  it('renders invalid even without invalidMessage', async () => {
+    const page = await newSpecPage({
+      components: [FileInputComponent],
+      html: `<admiralty-file-input invalid="true"></ukhho-file-input>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <admiralty-file-input invalid="true">
+        <div class="admiralty-file-input">
+          <label htmlfor="admiralty-file-input-5">
+            <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
+            <span>
+              Click to choose a file or drag it
+            </span>
+          </label>
+          <input aria-hidden="true" aria-label="File Upload" class="admiralty-form-field" id="admiralty-file-input-5" type="file">
+        </div>
+        <admiralty-input-invalid style="visibility: hidden;"></admiralty-input-invalid>
+      </admiralty-file-input>
+    `);
+  });
+
+  it('renders invalid with invalidMessage', async () => {
+    const page = await newSpecPage({
+      components: [FileInputComponent],
+      html: `<admiralty-file-input invalid="true" invalid-message="This is invalid!"></ukhho-file-input>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <admiralty-file-input invalid="true" invalid-message="This is invalid!">
+        <div class="admiralty-file-input">
+          <label htmlfor="admiralty-file-input-6">
+            <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
+            <span>
+              Click to choose a file or drag it
+            </span>
+          </label>
+          <input aria-hidden="true" aria-label="File Upload" class="admiralty-form-field" id="admiralty-file-input-6" type="file">
+        </div>
+        <admiralty-input-invalid style="visibility: visible;">
+          This is invalid!
+        </admiralty-input-invalid>
       </admiralty-file-input>
     `);
   });

--- a/packages/core/src/components/file-input/file-input.stories.ts
+++ b/packages/core/src/components/file-input/file-input.stories.ts
@@ -7,7 +7,7 @@ const meta: Meta = {
   title: 'Forms/File Input',
   parameters: {
     actions: {
-        handlers: ['fileInputChange'],
+      handlers: ['fileInputChange'],
     },
   },
 };
@@ -16,9 +16,17 @@ export default meta;
 
 type Story = StoryObj<FileInputComponent>;
 
-const template: Story = {
-  render: args => html`
-    <admiralty-file-input ?multiple=${args.multiple}></admiralty-file-input>`,
+export const Basic: Story = {
+  render: args => html` <admiralty-file-input ?multiple=${args.multiple}> </admiralty-file-input>`,
+  args: {
+    multiple: true,
+  },
 };
 
-export const Basic: Story = { ...template, args: { multiple: true } };
+export const Invalid: Story = {
+  render: args => html` <admiralty-file-input invalid="${args.invalid}" invalid-message="${args.invalidMessage}"> </admiralty-file-input>`,
+  args: {
+    invalid: true,
+    invalidMessage: 'That is not a real name',
+  },
+};

--- a/packages/core/src/components/file-input/file-input.tsx
+++ b/packages/core/src/components/file-input/file-input.tsx
@@ -20,6 +20,16 @@ export class FileInputComponent {
   @Prop() multiple = false;
 
   /**
+   * Whether to show that the file input is in an invalid state.
+   */
+  @Prop() invalid: boolean = false;
+
+  /**
+   * The message to show when the file input is invalid.
+   */
+  @Prop() invalidMessage: string = null;
+
+  /**
    * Emitted when the added file(s) changes
    */
   @Event() fileInputChange: EventEmitter<FileInputChangeEventDetail>;
@@ -115,6 +125,7 @@ export class FileInputComponent {
             multiple={this.multiple}
           />
         </div>
+        <admiralty-input-invalid style={{ visibility: this.invalid && this.invalidMessage ? 'visible' : 'hidden' }}>{this.invalidMessage}</admiralty-input-invalid>
       </Host>
     );
   }

--- a/packages/core/src/components/file-input/readme.md
+++ b/packages/core/src/components/file-input/readme.md
@@ -7,10 +7,12 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                                | Type      | Default                               |
-| ---------- | ---------- | ------------------------------------------------------------------------------------------ | --------- | ------------------------------------- |
-| `label`    | `label`    | Used to display instructions to the user and is replaced with the filename the user inputs | `string`  | `'Click to choose a file or drag it'` |
-| `multiple` | `multiple` | If true, enables multiple files to be selected or dragged                                  | `boolean` | `false`                               |
+| Property         | Attribute         | Description                                                                                | Type      | Default                               |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------------------ | --------- | ------------------------------------- |
+| `invalid`        | `invalid`         | Whether to show that the file input is in an invalid state.                                | `boolean` | `false`                               |
+| `invalidMessage` | `invalid-message` | The message to show when the file input is invalid.                                        | `string`  | `null`                                |
+| `label`          | `label`           | Used to display instructions to the user and is replaced with the filename the user inputs | `string`  | `'Click to choose a file or drag it'` |
+| `multiple`       | `multiple`        | If true, enables multiple files to be selected or dragged                                  | `boolean` | `false`                               |
 
 
 ## Events
@@ -25,11 +27,14 @@
 ### Depends on
 
 - [admiralty-icon](../icon)
+- [admiralty-input-invalid](../input-invalid)
 
 ### Graph
 ```mermaid
 graph TD;
   admiralty-file-input --> admiralty-icon
+  admiralty-file-input --> admiralty-input-invalid
+  admiralty-input-invalid --> admiralty-icon
   style admiralty-file-input fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/core/src/components/input-invalid/readme.md
+++ b/packages/core/src/components/input-invalid/readme.md
@@ -14,6 +14,7 @@
 
 ### Used by
 
+ - [admiralty-file-input](../file-input)
  - [admiralty-input](../input)
  - [admiralty-radio-group](../radio-group)
  - [admiralty-select](../select)
@@ -27,6 +28,7 @@
 ```mermaid
 graph TD;
   admiralty-input-invalid --> admiralty-icon
+  admiralty-file-input --> admiralty-input-invalid
   admiralty-input --> admiralty-input-invalid
   admiralty-radio-group --> admiralty-input-invalid
   admiralty-select --> admiralty-input-invalid


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.0--canary.121.9ba070a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.6.0--canary.121.9ba070a.0
  npm install @ukho/admiralty-core@0.6.0--canary.121.9ba070a.0
  # or 
  yarn add @ukho/admiralty-angular@0.6.0--canary.121.9ba070a.0
  yarn add @ukho/admiralty-core@0.6.0--canary.121.9ba070a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
