### PR TITLE
fix: Add missing border style for invalid file input

### DIFF
--- a/packages/core/src/components/file-input/file-input.scss
+++ b/packages/core/src/components/file-input/file-input.scss
@@ -15,6 +15,10 @@
   line-height: 24px;
   font-weight: 300;
 
+  &.invalid {
+    border-color: colours.$colour-utility-error;
+  }
+
   &.drop_zone {
     // active when file is dragged over label
     background: #fff !important;

--- a/packages/core/src/components/file-input/file-input.spec.ts
+++ b/packages/core/src/components/file-input/file-input.spec.ts
@@ -93,7 +93,7 @@ describe('file-input', () => {
     });
     expect(page.root).toEqualHtml(`
       <admiralty-file-input invalid="true">
-        <div class="admiralty-file-input">
+        <div class="admiralty-file-input invalid">
           <label htmlfor="admiralty-file-input-5">
             <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
             <span>
@@ -114,7 +114,7 @@ describe('file-input', () => {
     });
     expect(page.root).toEqualHtml(`
       <admiralty-file-input invalid="true" invalid-message="This is invalid!">
-        <div class="admiralty-file-input">
+        <div class="admiralty-file-input invalid">
           <label htmlfor="admiralty-file-input-6">
             <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
             <span>

--- a/packages/core/src/components/file-input/file-input.tsx
+++ b/packages/core/src/components/file-input/file-input.tsx
@@ -110,7 +110,7 @@ export class FileInputComponent {
   render() {
     return (
       <Host onDragLeave={event => this.dragLeaveHander(event)} onDragOver={event => this.dragOverHandler(event)} onDrop={event => this.dropHandler(event)}>
-        <div class="admiralty-file-input">
+        <div class={{ 'admiralty-file-input': true, 'invalid': this.invalid }}>
           <label htmlFor={this.id}>
             <admiralty-icon class="upload-icon" icon-name="upload"></admiralty-icon>
             <span>{this.label}</span>


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.1--canary.123.1355e01.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.7.1--canary.123.1355e01.0
  npm install @ukho/admiralty-core@0.7.1--canary.123.1355e01.0
  # or 
  yarn add @ukho/admiralty-angular@0.7.1--canary.123.1355e01.0
  yarn add @ukho/admiralty-core@0.7.1--canary.123.1355e01.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
