### PR TITLE
fix: Replace colour block click action with colourBlockLinkClicked event

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -133,25 +133,31 @@ export declare interface AdmiraltyCheckbox extends Components.AdmiraltyCheckbox 
 
 
 @ProxyCmp({
-  inputs: ['actionText', 'clickAction', 'colour', 'heading', 'height', 'width']
+  inputs: ['actionText', 'colour', 'heading', 'height', 'width']
 })
 @Component({
   selector: 'admiralty-colour-block',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['actionText', 'clickAction', 'colour', 'heading', 'height', 'width'],
+  inputs: ['actionText', 'colour', 'heading', 'height', 'width'],
 })
 export class AdmiraltyColourBlock {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
+    proxyOutputs(this, this.el, ['colourBlockLinkClicked']);
   }
 }
 
 
-export declare interface AdmiraltyColourBlock extends Components.AdmiraltyColourBlock {}
+export declare interface AdmiraltyColourBlock extends Components.AdmiraltyColourBlock {
+  /**
+   * An event emitted when this Colour Block link is clicked
+   */
+  colourBlockLinkClicked: EventEmitter<CustomEvent<string>>;
+}
 
 
 @ProxyCmp({

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -93,10 +93,6 @@ export namespace Components {
          */
         "actionText": string;
         /**
-          * The function to call when the action button is pressed.
-         */
-        "clickAction": () => any;
-        /**
           * The background colour of the component.
          */
         "colour": 'admiralty-blue' | 'teal' | 'bright-blue';
@@ -591,6 +587,10 @@ export namespace Components {
 export interface AdmiraltyCheckboxCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLAdmiraltyCheckboxElement;
+}
+export interface AdmiraltyColourBlockCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLAdmiraltyColourBlockElement;
 }
 export interface AdmiraltyExpansionCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -1088,10 +1088,6 @@ declare namespace LocalJSX {
          */
         "actionText"?: string;
         /**
-          * The function to call when the action button is pressed.
-         */
-        "clickAction"?: () => any;
-        /**
           * The background colour of the component.
          */
         "colour"?: 'admiralty-blue' | 'teal' | 'bright-blue';
@@ -1103,6 +1099,10 @@ declare namespace LocalJSX {
           * The height in pixels of the component.
          */
         "height"?: number;
+        /**
+          * An event emitted when this Colour Block link is clicked
+         */
+        "onColourBlockLinkClicked"?: (event: AdmiraltyColourBlockCustomEvent<string>) => void;
         /**
           * The width in pixels of the component.
          */

--- a/packages/core/src/components/colour-block/colour-block.spec.ts
+++ b/packages/core/src/components/colour-block/colour-block.spec.ts
@@ -16,4 +16,28 @@ describe('admiralty-colour-block', () => {
       </admiralty-colour-block>
     `);
   });
+
+  it('should emit colourBlockLinkClicked event when emitColourBlockLinkClicked() is called', () => {
+    const colourBlockComponent = new ColourBlockComponent();
+
+    const colourBlockLinkClickedEmitSpy = jest.spyOn(colourBlockComponent.colourBlockLinkClicked, 'emit');
+
+    expect(colourBlockLinkClickedEmitSpy).toHaveBeenCalledTimes(0);
+
+    colourBlockComponent.emitColourBlockLinkClicked();
+
+    expect(colourBlockLinkClickedEmitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call emitColourBlockLinkClicked() when handleClickAction() is called', () => {
+    const colourBlockComponent = new ColourBlockComponent();
+
+    const colourBlockLinkClickedEmitSpy = jest.spyOn(colourBlockComponent.colourBlockLinkClicked, 'emit');
+
+    expect(colourBlockLinkClickedEmitSpy).toHaveBeenCalledTimes(0);
+
+    colourBlockComponent.handleClickAction();
+
+    expect(colourBlockLinkClickedEmitSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/core/src/components/colour-block/colour-block.stories.ts
+++ b/packages/core/src/components/colour-block/colour-block.stories.ts
@@ -18,19 +18,11 @@ export default meta;
 type Story = StoryObj<ColourBlockComponent>;
 
 const template: Story = {
-  render: args => html`
-  <admiralty-colour-block
-      action-text="${args.actionText}"
-      width="${args.width}"
-      height="${args.height}"
-      heading="${args.heading}"
-      colour="${args.colour}"
-      click-action="${args.clickAction}"
-    >
+  render: args => html` <admiralty-colour-block action-text="${args.actionText}" width="${args.width}" height="${args.height}" heading="${args.heading}" colour="${args.colour}">
       <div>${unsafeHTML(args.content)}</div>
     </admiralty-colour-block>
     <script>
-      document.querySelector('admiralty-colour-block').clickAction = () => console.log('click');
+      document.querySelector('admiralty-colour-block').addEventListener('colourBlockLinkClicked', () => console.log('colourBlockLinkClicked'));
     </script>`,
 };
 

--- a/packages/core/src/components/colour-block/colour-block.tsx
+++ b/packages/core/src/components/colour-block/colour-block.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
 import { ButtonVariant } from '../button/button.types';
 
 @Component({
@@ -24,9 +24,17 @@ export class ColourBlockComponent {
    */
   @Prop() colour: 'admiralty-blue' | 'teal' | 'bright-blue' = 'admiralty-blue';
   /**
-   * The function to call when the action button is pressed.
+   * An event emitted when this Colour Block link is clicked
    */
-  @Prop() clickAction: () => any;
+  @Event() colourBlockLinkClicked: EventEmitter<string>;
+
+  handleClickAction() {
+    this.emitColourBlockLinkClicked();
+  }
+
+  emitColourBlockLinkClicked() {
+    this.colourBlockLinkClicked.emit();
+  }
   /**
    * The text to display on the action button
    */
@@ -53,8 +61,8 @@ export class ColourBlockComponent {
         >
           <slot></slot>
         </div>
-        {this.clickAction && this.actionText ? (
-          <admiralty-button variant={ButtonVariant.Text} class="clickAction" onClick={this.clickAction.bind(this)}>
+        {this.actionText ? (
+          <admiralty-button variant={ButtonVariant.Text} class="clickAction" onClick={this.handleClickAction.bind(this)}>
             <h3>{this.actionText}</h3>
           </admiralty-button>
         ) : null}

--- a/packages/core/src/components/colour-block/readme.md
+++ b/packages/core/src/components/colour-block/readme.md
@@ -7,14 +7,20 @@
 
 ## Properties
 
-| Property      | Attribute     | Description                                             | Type                                          | Default            |
-| ------------- | ------------- | ------------------------------------------------------- | --------------------------------------------- | ------------------ |
-| `actionText`  | `action-text` | The text to display on the action button                | `string`                                      | `undefined`        |
-| `clickAction` | --            | The function to call when the action button is pressed. | `() => any`                                   | `undefined`        |
-| `colour`      | `colour`      | The background colour of the component.                 | `"admiralty-blue" \| "bright-blue" \| "teal"` | `'admiralty-blue'` |
-| `heading`     | `heading`     | The heading text to display.                            | `string`                                      | `undefined`        |
-| `height`      | `height`      | The height in pixels of the component.                  | `number`                                      | `undefined`        |
-| `width`       | `width`       | The width in pixels of the component.                   | `number`                                      | `undefined`        |
+| Property     | Attribute     | Description                              | Type                                          | Default            |
+| ------------ | ------------- | ---------------------------------------- | --------------------------------------------- | ------------------ |
+| `actionText` | `action-text` | The text to display on the action button | `string`                                      | `undefined`        |
+| `colour`     | `colour`      | The background colour of the component.  | `"admiralty-blue" \| "bright-blue" \| "teal"` | `'admiralty-blue'` |
+| `heading`    | `heading`     | The heading text to display.             | `string`                                      | `undefined`        |
+| `height`     | `height`      | The height in pixels of the component.   | `number`                                      | `undefined`        |
+| `width`      | `width`       | The width in pixels of the component.    | `number`                                      | `undefined`        |
+
+
+## Events
+
+| Event                    | Description                                             | Type                  |
+| ------------------------ | ------------------------------------------------------- | --------------------- |
+| `colourBlockLinkClicked` | An event emitted when this Colour Block link is clicked | `CustomEvent<string>` |
 
 
 ## Dependencies

--- a/packages/docs/components/colour-block/events.mdx
+++ b/packages/docs/components/colour-block/events.mdx
@@ -1,1 +1,5 @@
-No events available for this component.
+
+| Name | Description |
+| --- | --- |
+| `colourBlockLinkClicked` | An event emitted when this Colour Block link is clicked |
+

--- a/packages/docs/components/colour-block/props.mdx
+++ b/packages/docs/components/colour-block/props.mdx
@@ -2,7 +2,6 @@
   | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `action-text` | `string` | `undefined` | The text to display on the action button |
-| `undefined` | `() => any` | `undefined` | The function to call when the action button is pressed. |
 | `colour` | `"admiralty-blue" ｜ "bright-blue" ｜ "teal"` | `'admiralty-blue'` | The background colour of the component. |
 | `heading` | `string` | `undefined` | The heading text to display. |
 | `height` | `number` | `undefined` | The height in pixels of the component. |

--- a/packages/docs/plugins/websiteDocsGenerator.ts
+++ b/packages/docs/plugins/websiteDocsGenerator.ts
@@ -153,8 +153,7 @@ ${slots.map((slot) => `| \`${slot.name}\` | ${formatMultiline(slot.docs)} |`).jo
  * @returns The formatted string
  */
 const formatMultiline = (str: string) => {
-    // return str;
-    return str.split('\n').join('<br /><br />');
+  return str.split('\r\n').join('<br /><br />').split('\n').join(' ');
 };
 
 const formatType = (attr: string, type: string) => {

--- a/packages/docs/plugins/websiteDocsGenerator.ts
+++ b/packages/docs/plugins/websiteDocsGenerator.ts
@@ -153,7 +153,8 @@ ${slots.map((slot) => `| \`${slot.name}\` | ${formatMultiline(slot.docs)} |`).jo
  * @returns The formatted string
  */
 const formatMultiline = (str: string) => {
-  return str.split('\r\n').join('<br /><br />').split('\n').join(' ');
+    // return str;
+    return str.split('\n').join('<br /><br />');
 };
 
 const formatType = (attr: string, type: string) => {

--- a/packages/test-app/src/app/app.component.html
+++ b/packages/test-app/src/app/app.component.html
@@ -26,7 +26,7 @@
   height="400"
   heading="Colour block"
   colour="admiralty-blue"
-  click-action="onColourBlockClick"
+  (colourBlockLinkClicked)="onColourBlockClick()"
 >
   <div>
     <p>This colour block is a component in the design system and we hope you enjoy it</p>

--- a/packages/website/src/components/colour-blocks/colour-blocks.tsx
+++ b/packages/website/src/components/colour-blocks/colour-blocks.tsx
@@ -10,7 +10,7 @@ export default function ColourBlocks() {
         colour="admiralty-blue"
         heading="Setting it up"
         actionText="Get started"
-        clickAction={() => alert("test")}>
+        onColourBlockLinkClicked={() => alert("test")}>
         Go to Get Started to see how to install the Design System and start using it in your builds.
       </AdmiraltyColourBlock>
       <AdmiraltyColourBlock
@@ -19,7 +19,7 @@ export default function ColourBlocks() {
         colour="teal"
         heading="How we do things"
         actionText="Principles"
-        clickAction={() => alert("test")}>
+        onColourBlockLinkClicked={() => alert("test")}>
         Our Principles section covers our approach to accessibility, design, research and content
       </AdmiraltyColourBlock>
       <AdmiraltyColourBlock
@@ -28,7 +28,7 @@ export default function ColourBlocks() {
         colour="bright-blue"
         heading="Component examples"
         actionText="Components"
-        clickAction={() => alert("test")}>
+        onColourBlockLinkClicked={() => alert("test")}>
         Visit Components to see examples, usage and accessibility requirements and get the code
       </AdmiraltyColourBlock>
       <AdmiraltyColourBlock
@@ -37,7 +37,7 @@ export default function ColourBlocks() {
         colour="teal"
         heading="Support user needs"
         actionText="Patterns"
-        clickAction={() => alert("test")}>
+        onColourBlockLinkClicked={() => alert("test")}>
         Patterns have been developed to meet a user need - such as ‘find a location’ or ‘complete a form’
       </AdmiraltyColourBlock>
       <AdmiraltyColourBlock
@@ -46,7 +46,7 @@ export default function ColourBlocks() {
         colour="bright-blue"
         heading="Build ‘on brand’"
         actionText="Brand guide"
-        clickAction={() => alert("test")}>
+        onColourBlockLinkClicked={() => alert("test")}>
         The Design System helps teams develop products in the ADMIRALTY brand
       </AdmiraltyColourBlock>
     </div>


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.0--canary.139.1ac840a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.8.0--canary.139.1ac840a.0
  npm install @ukho/admiralty-core@0.8.0--canary.139.1ac840a.0
  # or 
  yarn add @ukho/admiralty-angular@0.8.0--canary.139.1ac840a.0
  yarn add @ukho/admiralty-core@0.8.0--canary.139.1ac840a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
