### PR TITLE
Adding the ability to turn off the signout and account button on the header profile

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -373,14 +373,14 @@ export declare interface AdmiraltyHeaderMenuItem extends Components.AdmiraltyHea
 
 
 @ProxyCmp({
-  inputs: ['isSignedIn', 'signedInText']
+  inputs: ['isSignedIn', 'signInOnly', 'signedInText']
 })
 @Component({
   selector: 'admiralty-header-profile',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['isSignedIn', 'signedInText'],
+  inputs: ['isSignedIn', 'signInOnly', 'signedInText'],
 })
 export class AdmiraltyHeaderProfile {
   protected el: HTMLElement;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -223,6 +223,10 @@ export namespace Components {
          */
         "isSignedIn": boolean;
         /**
+          * A boolean to indicate if the component should hide the sign-out and account buttons, useful for internal sites where the user must be always signed in.
+         */
+        "signInOnly": boolean;
+        /**
           * The text that is displayed after the user signs in
          */
         "signedInText": string;
@@ -1257,6 +1261,10 @@ declare namespace LocalJSX {
           * The event that is fired when the user clicks on the 'Your account' button
          */
         "onYourAccountClicked"?: (event: AdmiraltyHeaderProfileCustomEvent<void>) => void;
+        /**
+          * A boolean to indicate if the component should hide the sign-out and account buttons, useful for internal sites where the user must be always signed in.
+         */
+        "signInOnly"?: boolean;
         /**
           * The text that is displayed after the user signs in
          */

--- a/packages/core/src/components/header-profile/header-profile.tsx
+++ b/packages/core/src/components/header-profile/header-profile.tsx
@@ -20,6 +20,13 @@ export class HeaderProfileComponent {
   @Prop() signedInText: string = 'replace';
 
   /**
+   * A boolean to indicate if the component should hide
+   * the sign-out and account buttons, useful for internal
+   * sites where the user must be always signed in.
+   */
+  @Prop() signInOnly: boolean = false;
+
+  /**
    * The event that is fired when the user clicks on
    * the sign in button
    */
@@ -45,7 +52,7 @@ export class HeaderProfileComponent {
     if (ev.key === Keys.ENTER || ev.key === Keys.SPACE) {
       this.signInClicked.emit();
     }
-  }
+  };
 
   handleSignOut = () => {
     this.signOutClicked.emit();
@@ -55,7 +62,7 @@ export class HeaderProfileComponent {
     if (ev.key === Keys.ENTER || ev.key === Keys.SPACE) {
       this.signOutClicked.emit();
     }
-  }
+  };
 
   handleYourAccount = () => {
     this.yourAccountClicked.emit();
@@ -65,7 +72,7 @@ export class HeaderProfileComponent {
     if (ev.key === Keys.ENTER || ev.key === Keys.SPACE) {
       this.yourAccountClicked.emit();
     }
-  }
+  };
 
   closeDropdown = () => {
     const subMenu: HTMLDivElement = this.el.querySelector('div.sub-menu');
@@ -84,42 +91,51 @@ export class HeaderProfileComponent {
     }
   };
 
-  handleClickSignedIn = (ev: MouseEvent) =>{
+  handleClickSignedIn = (ev: MouseEvent) => {
     ev.stopPropagation();
     this.toggleDropdown(ev);
-  }
+  };
 
   render() {
-    let { isSignedIn, signedInText } = this;
+    let { isSignedIn, signedInText, signInOnly } = this;
     return (
       <Host>
         <div class="header-profile">
           {isSignedIn ? (
             <div>
-              <div class="desktop"
-                onMouseOver={this.toggleDropdown}
-              >
-                <button
-                  onClick={this.handleClickSignedIn}
-                  tabindex="0">
+              <div class="desktop" onMouseOver={this.toggleDropdown}>
+                <button onClick={this.handleClickSignedIn} tabindex="0">
                   {signedInText}
                 </button>
-                <div class="sub-menu desktop-hide">
-                  <button class="sub-menu-item" onClick={this.handleYourAccount} tabindex="0">Your Account</button>
-                  <button  class="sub-menu-item" onClick={this.handleSignOut} tabindex="0">Sign Out</button>
+                {!signInOnly ? (
+                  <div class="sub-menu desktop-hide">
+                    <button class="sub-menu-item" onClick={this.handleYourAccount} tabindex="0">
+                      Your Account
+                    </button>
+                    <button class="sub-menu-item" onClick={this.handleSignOut} tabindex="0">
+                      Sign Out
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+              {!signInOnly ? (
+                <div class="not-desktop">
+                  <div class="sub-menu-item" onClick={this.handleYourAccount} onKeyDown={this.handleYourAccountKeyDown} tabindex="0">
+                    Your Account
+                  </div>
+                  <div class="sub-menu-item" onClick={this.handleSignOut} onKeyDown={this.handleSignOutKeyDown} tabindex="0">
+                    Sign Out
+                  </div>
                 </div>
-              </div>
-              <div class="not-desktop">
-                <div class="sub-menu-item" onClick={this.handleYourAccount} onKeyDown={this.handleYourAccountKeyDown} tabindex="0">Your Account</div>
-                <div class="sub-menu-item" onClick={this.handleSignOut}  onKeyDown={this.handleSignOutKeyDown} tabindex="0">Sign Out</div>
-              </div>
+              ) : null}
             </div>
           ) : (
-            <button class="sub-menu-item" onClick={this.handleSignIn} tabindex="0">Sign In</button>
+            <button class="sub-menu-item" onClick={this.handleSignIn} tabindex="0">
+              Sign In
+            </button>
           )}
         </div>
       </Host>
     );
   }
-
 }

--- a/packages/core/src/components/header-profile/readme.md
+++ b/packages/core/src/components/header-profile/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property       | Attribute        | Description                                           | Type      | Default     |
-| -------------- | ---------------- | ----------------------------------------------------- | --------- | ----------- |
-| `isSignedIn`   | `is-signed-in`   | A boolean to indicate if the user is signed in or not | `boolean` | `false`     |
-| `signedInText` | `signed-in-text` | The text that is displayed after the user signs in    | `string`  | `'replace'` |
+| Property       | Attribute        | Description                                                                                                                                             | Type      | Default     |
+| -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `isSignedIn`   | `is-signed-in`   | A boolean to indicate if the user is signed in or not                                                                                                   | `boolean` | `false`     |
+| `signInOnly`   | `sign-in-only`   | A boolean to indicate if the component should hide the sign-out and account buttons, useful for internal sites where the user must be always signed in. | `boolean` | `false`     |
+| `signedInText` | `signed-in-text` | The text that is displayed after the user signs in                                                                                                      | `string`  | `'replace'` |
 
 
 ## Events

--- a/packages/core/src/components/header/header.stories.ts
+++ b/packages/core/src/components/header/header.stories.ts
@@ -15,7 +15,7 @@ const meta: Meta = {
   title: 'Header',
   parameters: {
     actions: {
-        handles: ['titledClicked', 'menuItemClick', 'subMenuItemClick','signInClicked','yourAccountClicked','signOutClicked']
+      handles: ['titledClicked', 'menuItemClick', 'subMenuItemClick', 'signInClicked', 'yourAccountClicked', 'signOutClicked'],
     },
   },
 };
@@ -35,13 +35,19 @@ const defaultArgs = {
 const profileArgs = {
   signedIn: false,
   singedInText: 'Mr Admiral',
+  signInOnly: false,
 };
 
 const TemplateSignedOut: Story = {
-  render: args => html`
-    <admiralty-header logo-alt-text="${args.logoAltText}" logo-link-url="${args.logoLinkUrl}" logo-img-url="${args.logoImgUrl}" header-title-url="#" header-title="${args.title}">
-      <admiralty-header-profile is-signed-in="${args.signedIn}" signed-in-text="${args.singedInText}" slot="profile"></admiralty-header-profile>
-    </admiralty-header>`
+  render: args => html` <admiralty-header
+    logo-alt-text="${args.logoAltText}"
+    logo-link-url="${args.logoLinkUrl}"
+    logo-img-url="${args.logoImgUrl}"
+    header-title-url="#"
+    header-title="${args.title}"
+  >
+    <admiralty-header-profile is-signed-in="${args.signedIn}" signed-in-text="${args.singedInText}" sign-in-only="${args.signInOnly}" slot="profile"></admiralty-header-profile>
+  </admiralty-header>`,
 };
 
 const TemplateLinksAndAuth: Story = {
@@ -51,17 +57,17 @@ const TemplateLinksAndAuth: Story = {
       return `<admiralty-header-menu-item menu-title="${item.title}" active="${item.navActive ?? false}" slot="items">${subItems?.join('')}</admiralty-header-menu-item>
     `;
     });
-  
-    let template = `<admiralty-header logo-alt-text="${args.logoAltText}" logo-link-url="${args.logoLinkUrl}" logo-img-url="${args.logoImgUrl}" header-title-url="#" header-title="${
-      args.title
-    }">
+
+    let template = `<admiralty-header logo-alt-text="${args.logoAltText}" logo-link-url="${args.logoLinkUrl}" logo-img-url="${
+      args.logoImgUrl
+    }" header-title-url="#" header-title="${args.title}">
       ${menuItems?.join('')}
       <admiralty-header-profile is-signed-in="${args.signedIn}" signed-in-text="${args.singedInText}" slot="profile"></admiralty-header-profile>
     </admiralty-header>`;
-  
+
     console.log(template);
     return html`${unsafeHTML(template)}`;
-  }
+  },
 };
 
 const TemplateLinksNoAuth: Story = {
@@ -71,75 +77,81 @@ const TemplateLinksNoAuth: Story = {
       return `<admiralty-header-menu-item menu-title="${item.title}" active="${item.navActive ?? false}" slot="items">${subItems?.join('') ?? ''}</admiralty-header-menu-item>
     `;
     });
-  
-    let template = `<admiralty-header logo-alt-text="${args.logoAltText}" logo-link-url="${args.logoLinkUrl}" logo-img-url="${args.logoImgUrl}" header-title-url="#" header-title="${
-      args.title
-    }">
+
+    let template = `<admiralty-header logo-alt-text="${args.logoAltText}" logo-link-url="${args.logoLinkUrl}" logo-img-url="${
+      args.logoImgUrl
+    }" header-title-url="#" header-title="${args.title}">
       ${menuItems?.join('') ?? ''}
     </admiralty-header>`;
-  
+
     console.log(template);
     return html`${unsafeHTML(template)}`;
-  }
+  },
 };
 
-export const linksAndAuthNotSignedIn: Story = { ...TemplateLinksAndAuth,
+export const linksAndAuthNotSignedIn: Story = {
+  ...TemplateLinksAndAuth,
   args: {
     menuItems: mockMenuItemsWithSubItems,
     ...defaultArgs,
-    ...profileArgs
-  }
+    ...profileArgs,
+  },
 };
 
-export const linksWithNoSubItems: Story = { ...TemplateLinksNoAuth,
+export const linksWithNoSubItems: Story = {
+  ...TemplateLinksNoAuth,
   args: {
     menuItems: mockMenuItemsWithNoSubItems,
     ...defaultArgs,
-    logoImgUrl: 'svg/UKHO linear logo.svg'
-  }
+    logoImgUrl: 'svg/UKHO linear logo.svg',
+  },
 };
 
-export const linksWithNoSubItemsAndNavActive: Story = { ...TemplateLinksNoAuth,
+export const linksWithNoSubItemsAndNavActive: Story = {
+  ...TemplateLinksNoAuth,
   args: {
     menuItems: mockMenuItemsWithNoSubItemsAndNavActive,
-    ...defaultArgs
-  }
+    ...defaultArgs,
+  },
 };
 
-export const linksWithSubItemsAndNavActive: Story = { ...TemplateLinksNoAuth,
+export const linksWithSubItemsAndNavActive: Story = {
+  ...TemplateLinksNoAuth,
   args: {
     menuItems: mockMenuItemsWithSubItemsAndNavActive,
-    ...defaultArgs
-  }
+    ...defaultArgs,
+  },
 };
 
-export const linksWithSomeSubItems: Story = { ...TemplateLinksNoAuth,
+export const linksWithSomeSubItems: Story = {
+  ...TemplateLinksNoAuth,
   args: {
     menuItems: mockMenuItemsWithSomeSubItems,
-    ...defaultArgs
-  }
+    ...defaultArgs,
+  },
 };
 
-export const noLinks: Story = { render: args => html`
-  <admiralty-header header-title="${args.title}" logo-link-url="${args.logoLinkUrl}" headerTitleUrl="${args.titleLinkUrl}">
-  </admiralty-header>`,
+export const noLinks: Story = {
+  render: args => html` <admiralty-header header-title="${args.title}" logo-link-url="${args.logoLinkUrl}" headerTitleUrl="${args.titleLinkUrl}"> </admiralty-header>`,
   args: {
     ...defaultArgs,
     titleLinkUrl: null,
-  }
+  },
 };
 
-export const HeaderSignedIn: Story = { ...TemplateSignedOut,
+export const HeaderSignedIn: Story = {
+  ...TemplateSignedOut,
   args: {
     ...defaultArgs,
     ...profileArgs,
-    signedIn: true
-  }
+    signedIn: true,
+  },
 };
 
-export const HeaderSignedOut: Story = { ...TemplateSignedOut,
+export const HeaderSignedOut: Story = {
+  ...TemplateSignedOut,
   args: {
     ...defaultArgs,
-    ...profileArgs
-  }
+    ...profileArgs,
+  },
 };

--- a/packages/docs/components/header-profile/events.mdx
+++ b/packages/docs/components/header-profile/events.mdx
@@ -1,7 +1,7 @@
 
 | Name | Description |
 | --- | --- |
-| `signInClicked` | The event that is fired when the user clicks on<br /><br />the sign in button |
-| `signOutClicked` | The event that is fired when the user clicks on the<br /><br />'sign out' button |
-| `yourAccountClicked` | The event that is fired when the user clicks on the<br /><br />'Your account' button |
+| `signInClicked` | The event that is fired when the user clicks on the sign in button |
+| `signOutClicked` | The event that is fired when the user clicks on the 'sign out' button |
+| `yourAccountClicked` | The event that is fired when the user clicks on the 'Your account' button |
 

--- a/packages/docs/components/header-profile/props.mdx
+++ b/packages/docs/components/header-profile/props.mdx
@@ -2,5 +2,6 @@
   | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `is-signed-in` | `boolean` | `false` | A boolean to indicate if the user is signed in or not |
+| `sign-in-only` | `boolean` | `false` | A boolean to indicate if the component should hide the sign-out and account buttons, useful for internal sites where the user must be always signed in. |
 | `signed-in-text` | `string` | `'replace'` | The text that is displayed after the user signs in |
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.0--canary.150.0fef015.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.10.0--canary.150.0fef015.0
  npm install @ukho/admiralty-core@0.10.0--canary.150.0fef015.0
  # or 
  yarn add @ukho/admiralty-angular@0.10.0--canary.150.0fef015.0
  yarn add @ukho/admiralty-core@0.10.0--canary.150.0fef015.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
