### PR TITLE
fix: page width on design system website

### DIFF
--- a/packages/core/src/components/modal-dialog/modal-dialog.stories.ts
+++ b/packages/core/src/components/modal-dialog/modal-dialog.stories.ts
@@ -15,16 +15,17 @@ export default meta;
 type Story = StoryObj<ModalDialogComponent>;
 
 export const Basic: Story = {
-  render: args => html`<admiralty-modal-dialog heading="${args.heading}" ?show="${args.show}" label="${args.label}" description="${args.description}">
-    <div slot="content">
-      <admiralty-icon icon-name="triangle-exclamation" icon-prefix="fas"></admiralty-icon>
-      <div>If you leave this page, your survey won&apos;t be saved and can&apos;t be recovered</div>
-    </div>
-    <div slot="actions">
-      <admiralty-button variant="secondary">Leave page</admiralty-button>
-      <admiralty-button>Continue survey</admiralty-button>
-    </div>
-  </admiralty-modal-dialog>`,
+  render: args =>
+    html`<admiralty-modal-dialog heading="${args.heading}" ?show="${args.show}" label="${args.label}" description="${args.description}">
+      <div slot="content">
+        <admiralty-icon icon-name="triangle-exclamation" icon-prefix="fas"></admiralty-icon>
+        <div>If you leave this page, your survey won't be saved and can't be recovered</div>
+      </div>
+      <div slot="actions">
+        <admiralty-button variant="secondary">Leave page</admiralty-button>
+        <admiralty-button>Continue survey</admiralty-button>
+      </div>
+    </admiralty-modal-dialog>`,
   args: {
     heading: 'Do you want to leave this page?',
     show: true,
@@ -41,16 +42,17 @@ export const Basic: Story = {
 };
 
 export const Hidden: Story = {
-  render: args => html`<admiralty-modal-dialog heading="${args.heading}" ?show="${args.show}" label="${args.label}" description="${args.description}">
-    <div slot="content">
-      <admiralty-icon icon-name="triangle-exclamation" icon-prefix="fas"></admiralty-icon>
-      <div>If you leave this page, your survey won&apos;t be saved and can&apos;t be recovered</div>
-    </div>
-    <div slot="actions">
-      <admiralty-button variant="secondary">Leave page</admiralty-button>
-      <admiralty-button>Continue survey</admiralty-button>
-    </div>
-  </admiralty-modal-dialog>`,
+  render: args =>
+    html`<admiralty-modal-dialog heading="${args.heading}" ?show="${args.show}" label="${args.label}" description="${args.description}">
+      <div slot="content">
+        <admiralty-icon icon-name="triangle-exclamation" icon-prefix="fas"></admiralty-icon>
+        <div>If you leave this page, your survey won't be saved and can't be recovered</div>
+      </div>
+      <div slot="actions">
+        <admiralty-button variant="secondary">Leave page</admiralty-button>
+        <admiralty-button>Continue survey</admiralty-button>
+      </div>
+    </admiralty-modal-dialog>`,
   args: {
     heading: 'Do you want to leave this page?',
     show: false,

--- a/packages/core/src/components/tab-group/tab-group.tsx
+++ b/packages/core/src/components/tab-group/tab-group.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Prop, Event, h, EventEmitter, Host } from '@stencil/core';
+import { Component, Element, Prop, Event, h, EventEmitter, Host, forceUpdate } from '@stencil/core';
 import { Keys } from '../Keys';
 
 interface TabInfo {
@@ -144,6 +144,7 @@ export class TabGroupComponent {
       tabContent.after(...Array.from(tabItems));
 
       this.setSelectedTabContent();
+      forceUpdate(this);
     }
   }
 

--- a/packages/website/src/app/components/layout.tsx
+++ b/packages/website/src/app/components/layout.tsx
@@ -37,7 +37,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className={styles.contentContainer}>
       <SideNav rootPath="/components" items={sideNavItems} />
-      <div>{children}</div>
+      <div className={styles.content}>{children}</div>
     </div>
   );
 }

--- a/packages/website/src/app/components/styles.module.css
+++ b/packages/website/src/app/components/styles.module.css
@@ -2,3 +2,7 @@
   display: flex;
   padding: 60px 142px 0 142px;
 }
+
+.content {
+  min-width: 0;
+}

--- a/packages/website/src/components/copy-code-snippet/copy-code-snippet.tsx
+++ b/packages/website/src/components/copy-code-snippet/copy-code-snippet.tsx
@@ -25,7 +25,6 @@ export default function CopyCodeSnippet({ children, ...props }: CopyCodeSnippetP
 
   useEffect(() => {
     // Highlight code when component mounts or when children change
-    console.log(Prism.languages);
     Prism.highlightAll();
   }, [children]);
 

--- a/packages/website/src/components/copy-code-snippet/copy-code-snippet.tsx
+++ b/packages/website/src/components/copy-code-snippet/copy-code-snippet.tsx
@@ -10,7 +10,7 @@ interface CopyCodeSnippetProps {
   // Your other props here.
 }
 
-export default function CopyCodeSnippet({ children, ...props }: CopyCodeSnippetProps) {
+export default function CopyCodeSnippet({ children }: CopyCodeSnippetProps) {
   const codeRef = useRef<HTMLPreElement>(null);
 
   const [codeToCopy, setCodeToCopy] = useState("");

--- a/packages/website/src/usage/modal-dialog/basic/angular.mdx
+++ b/packages/website/src/usage/modal-dialog/basic/angular.mdx
@@ -3,10 +3,11 @@
   heading="Do you want to leave this page?"
   show="true"
   label="Do you want to leave this page?"
-  description="If you leave this page, your survey won't be saved and can't be recovered">
+  description="If you leave this page, your survey won't be saved and can't be recovered"
+>
   <div slot="content">
     <admiralty-icon icon-name="triangle-exclamation" icon-prefix="fas"></admiralty-icon>
-    <div>If you leave this page, your survey won&apos;t be saved and can&apos;t be recovered</div>
+    <div>If you leave this page, your survey won't be saved and can't be recovered</div>
   </div>
   <div slot="actions">
     <admiralty-button variant="secondary">Leave page</admiralty-button>

--- a/packages/website/src/usage/modal-dialog/basic/javascript.mdx
+++ b/packages/website/src/usage/modal-dialog/basic/javascript.mdx
@@ -3,10 +3,11 @@
   heading="Do you want to leave this page?"
   show="true"
   label="Do you want to leave this page?"
-  description="If you leave this page, your survey won't be saved and can't be recovered">
+  description="If you leave this page, your survey won't be saved and can't be recovered"
+>
   <div slot="content">
     <admiralty-icon icon-name="triangle-exclamation" icon-prefix="fas"></admiralty-icon>
-    <div>If you leave this page, your survey won&apos;t be saved and can&apos;t be recovered</div>
+    <div>If you leave this page, your survey won't be saved and can't be recovered</div>
   </div>
   <div slot="actions">
     <admiralty-button variant="secondary">Leave page</admiralty-button>

--- a/packages/website/src/usage/modal-dialog/basic/react.mdx
+++ b/packages/website/src/usage/modal-dialog/basic/react.mdx
@@ -1,12 +1,12 @@
-```html
+```tsx
 <AdmiraltyModalDialog
-      heading="Do you want to leave this page?"
-      show={true}
-      label="Do you want to leave this page?"
-      description="If you leave this page, your survey won't be saved and can't be recovered">
+  heading="Do you want to leave this page?"
+  show={true}
+  label="Do you want to leave this page?"
+  description="If you leave this page, your survey won't be saved and can't be recovered">
   <div slot="content">
     <AdmiraltyIcon icon-name="triangle-exclamation" icon-prefix="fas"></AdmiraltyIcon>
-    <div>If you leave this page, your survey won&apos;t be saved and can&apos;t be recovered</div>
+    <div>If you leave this page, your survey won't be saved and can't be recovered</div>
   </div>
   <div slot="actions">
     <AdmiraltyButton variant="secondary">Leave page</AdmiraltyButton>


### PR DESCRIPTION
Prevent the code examples on the component page from increasing the parent width beyond the visible width.

The code example will now scroll if the width exceeds the parent.

Before:
<img width="1627" alt="image" src="https://github.com/user-attachments/assets/e15b28b0-206b-4d76-ba90-20409cc4be9f">

After:
<img width="1627" alt="Screenshot 2024-07-29 at 17 19 56" src="https://github.com/user-attachments/assets/214c85dc-4158-487a-84c1-9d887bf89eb6">

Also fixed in this update is an issue where the default tab would not be selected when navigating between component pages.

Before:
<img width="1627" alt="Screenshot 2024-07-29 at 17 23 02" src="https://github.com/user-attachments/assets/7246af84-09b1-4a0e-9d0a-965062aec383">

After:
<img width="1627" alt="image" src="https://github.com/user-attachments/assets/29701e04-cb47-4567-9116-67da93bc9e83">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.14.2--canary.228.7b3918b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.14.2--canary.228.7b3918b.0
  npm install @ukho/admiralty-core@0.14.2--canary.228.7b3918b.0
  # or 
  yarn add @ukho/admiralty-angular@0.14.2--canary.228.7b3918b.0
  yarn add @ukho/admiralty-core@0.14.2--canary.228.7b3918b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
