### PR TITLE
Do not clear autocomplete default value before options have been rendered

### DIFF
--- a/packages/core/src/components/autocomplete/autocomplete.tsx
+++ b/packages/core/src/components/autocomplete/autocomplete.tsx
@@ -166,7 +166,10 @@ export class AutocompleteComponent {
 
   @Watch('value')
   onValueChange(newVal: string, _: string) {
-    // console.log('onValueChange', newVal);
+    if (this.source.length === 0) {
+      // If this is the initial render, the options won't have been set yet, so do nothing
+      return;
+    }
     if (newVal && newVal.length > 0) {
       const matches = filterOptionsByValue(this.source, newVal);
       const matchFound = matches.length > 0;


### PR DESCRIPTION
When the autocomplete and autocomplete options are rendered asynchronously, e.g. via an API, the initial value for the autocomplete was being cleared internally.

Add a check to only update the internal state if the options have rendered.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.18.1--canary.239.55e7b19.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@0.18.1--canary.239.55e7b19.0
  npm install @ukho/admiralty-core@0.18.1--canary.239.55e7b19.0
  # or 
  yarn add @ukho/admiralty-angular@0.18.1--canary.239.55e7b19.0
  yarn add @ukho/admiralty-core@0.18.1--canary.239.55e7b19.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
