### PR TITLE
Update focus highlights for header mobile menus 

### DIFF
--- a/packages/core/src/components/header-menu-item/header-menu-item.scss
+++ b/packages/core/src/components/header-menu-item/header-menu-item.scss
@@ -8,11 +8,13 @@
 }
 
 .menu-item {
-  color: colours.$colour-admiralty-blue;
   cursor: pointer;
 
   .menu-title {
-    font-size: typography.$font-size-normal;
+    div {
+      font-size: typography.$font-size-normal;
+      color: colours.$colour-admiralty-blue;
+    }
 
     &:focus div {
       @include a11y.focus-highlight;
@@ -90,8 +92,11 @@ button {
     text-decoration: unset;
 
     .menu-title {
-      padding: 12px;
-      font-weight: 500;
+      div {
+        display: inline-block;
+        margin: 12px;
+        font-weight: typography.$font-weight-medium;
+      }
 
       &:hover {
         background-color: colours.$colour-nav-bg-hover;

--- a/packages/core/src/components/header-menu-link/header-menu-link.scss
+++ b/packages/core/src/components/header-menu-link/header-menu-link.scss
@@ -14,6 +14,7 @@
     font-weight: typography.$font-weight-medium;
     text-decoration: none;
     outline-offset: 3px;
+    color: colours.$colour-admiralty-blue;
   }
 }
 
@@ -47,9 +48,23 @@
   .menu-item {
     display: block;
     box-sizing: border-box;
-    color: colours.$colour-admiralty-blue;
+
     background-color: unset;
     text-align: unset;
     text-decoration: unset;
+    padding: 12px;
+
+    a {
+      font-weight: typography.$font-weight-medium;
+      &:focus {
+        box-shadow:
+          0 -4px colours.$colour-utility-focus,
+          0 4px colours.$colour-text;
+      }
+    }
+
+    &:hover {
+      background-color: colours.$colour-nav-bg-hover;
+    }
   }
 }

--- a/packages/core/src/components/header-profile/header-profile.scss
+++ b/packages/core/src/components/header-profile/header-profile.scss
@@ -34,10 +34,13 @@
       all: unset;
       height: 100%;
       width: 100%;
-      div {
+      span {
+        color: colours.$colour-admiralty-blue;
         font-weight: typography.$font-weight-medium;
+        padding: 4px 8px;
       }
 
+      &:focus span,
       &:focus div {
         @include a11y.focus-highlight;
       }
@@ -92,10 +95,6 @@
         text-align: left;
         width: 100%;
 
-        &:focus {
-          outline: none;
-          box-shadow: colours.$colour-utility-focus inset 0 0 0 3px;
-        }
         &:hover {
           background-color: colours.$colour-nav-bg-hover;
         }
@@ -113,20 +112,28 @@
     .sub-menu-item {
       display: block;
       box-sizing: border-box;
-      font-size: typography.$font-size-normal;
-      font-weight: 500;
       background-color: unset;
       text-align: unset;
       text-decoration: unset;
-
+      width: 100%;
       padding: 12px;
+
+      span {
+        padding: 4px 0;
+        color: colours.$colour-admiralty-blue;
+        font-size: typography.$font-size-normal;
+        font-weight: typography.$font-weight-medium;
+      }
+
       &:hover {
         background-color: colours.$colour-nav-bg-hover;
       }
 
       &:focus {
         outline: none;
-        box-shadow: colours.$colour-utility-focus inset 0 0 0 3px;
+        span {
+          @include a11y.focus-highlight;
+        }
       }
     }
   }

--- a/packages/core/src/components/header-profile/header-profile.scss
+++ b/packages/core/src/components/header-profile/header-profile.scss
@@ -37,7 +37,7 @@
       span {
         color: colours.$colour-admiralty-blue;
         font-weight: typography.$font-weight-medium;
-        padding: 4px 8px;
+        padding: 4px 0;
       }
 
       &:focus span,

--- a/packages/core/src/components/header-profile/header-profile.spec.ts
+++ b/packages/core/src/components/header-profile/header-profile.spec.ts
@@ -12,9 +12,9 @@ describe('header-profile', () => {
       <admiralty-header-profile>
         <div class="header-profile">
           <button class="sub-menu-item" tabindex="0">
-            <div>
+            <span>
               Sign In
-            </div>
+            </span>
           </button>
         </div>
       </admiralty-header-profile>
@@ -30,9 +30,9 @@ describe('header-profile', () => {
       <admiralty-header-profile is-signed-in="false" signed-in-text="Mr Admiral">
         <div class="header-profile">
           <button class="sub-menu-item" tabindex="0">
-            <div>
+            <span>
               Sign In
-            </div>
+            </span>
           </button>
         </div>
       </admiralty-header-profile>
@@ -49,9 +49,9 @@ describe('header-profile', () => {
           <div>
             <div class="desktop">
               <button tabindex="0">
-                <div>
+                <span>
                   Mr Admiral
-                </div>
+                </span>
               </button>
               <div class="desktop-hide sub-menu">
                 <button class="sub-menu-item" tabindex="0">
@@ -67,12 +67,16 @@ describe('header-profile', () => {
               </div>
             </div>
             <div class="not-desktop">
-              <div class="sub-menu-item" tabindex="0">
-                Your Account
-              </div>
-              <div class="sub-menu-item" tabindex="0">
-                Sign Out
-              </div>
+              <button class="sub-menu-item" tabindex="0">
+                <span>
+                  Your Account
+                </span>
+              </button>
+              <button class="sub-menu-item" tabindex="0">
+                <span>
+                  Sign Out
+                </span>
+              </button>
             </div>
           </div>
         </div>

--- a/packages/core/src/components/header-profile/header-profile.tsx
+++ b/packages/core/src/components/header-profile/header-profile.tsx
@@ -1,5 +1,4 @@
 import { Component, Event, Host, h, Prop, EventEmitter, Element } from '@stencil/core';
-import { Keys } from '../Keys';
 
 @Component({
   tag: 'admiralty-header-profile',
@@ -48,30 +47,12 @@ export class HeaderProfileComponent {
     this.signInClicked.emit();
   };
 
-  handleSignInKeyDown = (ev: KeyboardEvent) => {
-    if (ev.key === Keys.ENTER || ev.key === Keys.SPACE) {
-      this.signInClicked.emit();
-    }
-  };
-
   handleSignOut = () => {
     this.signOutClicked.emit();
   };
 
-  handleSignOutKeyDown = (ev: KeyboardEvent) => {
-    if (ev.key === Keys.ENTER || ev.key === Keys.SPACE) {
-      this.signOutClicked.emit();
-    }
-  };
-
   handleYourAccount = () => {
     this.yourAccountClicked.emit();
-  };
-
-  handleYourAccountKeyDown = (ev: KeyboardEvent) => {
-    if (ev.key === Keys.ENTER || ev.key === Keys.SPACE) {
-      this.yourAccountClicked.emit();
-    }
   };
 
   closeDropdown = () => {
@@ -105,7 +86,7 @@ export class HeaderProfileComponent {
             <div>
               <div class="desktop" onMouseOver={this.toggleDropdown}>
                 <button onClick={this.handleClickSignedIn} tabindex="0">
-                  <div>{signedInText}</div>
+                  <span>{signedInText}</span>
                 </button>
                 {!signInOnly ? (
                   <div class="sub-menu desktop-hide">
@@ -120,18 +101,18 @@ export class HeaderProfileComponent {
               </div>
               {!signInOnly ? (
                 <div class="not-desktop">
-                  <div class="sub-menu-item" onClick={this.handleYourAccount} onKeyDown={this.handleYourAccountKeyDown} tabindex="0">
-                    Your Account
-                  </div>
-                  <div class="sub-menu-item" onClick={this.handleSignOut} onKeyDown={this.handleSignOutKeyDown} tabindex="0">
-                    Sign Out
-                  </div>
+                  <button class="sub-menu-item" onClick={this.handleYourAccount} tabindex="0">
+                    <span>Your Account</span>
+                  </button>
+                  <button class="sub-menu-item" onClick={this.handleSignOut} tabindex="0">
+                    <span>Sign Out</span>
+                  </button>
                 </div>
               ) : null}
             </div>
           ) : (
             <button class="sub-menu-item" onClick={this.handleSignIn} tabindex="0">
-              <div>Sign In</div>
+              <span>Sign In</span>
             </button>
           )}
         </div>

--- a/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.scss
+++ b/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.scss
@@ -8,6 +8,8 @@
 }
 
 .header-sub-menu-item {
+  background-color: colours.$colour-bg;
+
   .title {
     font-size: typography.$font-size-normal;
     font-weight: typography.$font-weight-light;
@@ -27,12 +29,11 @@
     display: block;
     margin-bottom: 0;
     padding: 10px;
-    text-align: center;
+    text-align: left;
     width: 300px;
 
     .title {
       display: block;
-      text-align: center;
     }
 
     &:hover {

--- a/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.scss
+++ b/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.scss
@@ -1,6 +1,7 @@
-@use "../../scss/vars/colours" as colours;
-@use "../../scss/base/responsive";
-@use "../../scss/vars/typography";
+@use '../../scss/vars/colours' as colours;
+@use '../../scss/base/responsive';
+@use '../../scss/vars/typography';
+@use '../../scss/base/a11y';
 
 @mixin active {
   background-color: colours.$colour-nav-bg-hover;
@@ -14,7 +15,10 @@
 
   &:focus {
     outline: none;
-    box-shadow: colours.$colour-utility-focus inset 0 0 0 3px;
+
+    span {
+      @include a11y.focus-highlight;
+    }
   }
 
   @include responsive.desktop-only {
@@ -22,13 +26,12 @@
     color: colours.$colour-admiralty-blue;
     display: block;
     margin-bottom: 0;
-    padding: 0 0.66em;
+    padding: 10px;
     text-align: center;
     width: 300px;
 
     .title {
       display: block;
-      padding: 10px;
       text-align: center;
     }
 
@@ -53,8 +56,11 @@
     }
 
     &:focus {
-      outline: none;
-      box-shadow: colours.$colour-utility-focus inset 0 0 0 3px;
+      .title {
+        box-shadow:
+          0 -4px colours.$colour-utility-focus,
+          0 4px colours.$colour-text;
+      }
     }
   }
 }

--- a/packages/core/src/components/header/header.scss
+++ b/packages/core/src/components/header/header.scss
@@ -126,8 +126,10 @@
       }
 
       &:focus {
+        @include a11y.focus-highlight;
+
         outline: none;
-        box-shadow: colours.$colour-utility-focus inset 0 0 0 3px;
+        box-shadow: 0 -4px colours.$colour-text inset;
       }
     }
   }

--- a/packages/core/src/components/header/header.spec.ts
+++ b/packages/core/src/components/header/header.spec.ts
@@ -29,7 +29,7 @@ describe('admiralty-header', () => {
             </div>
             <div class="header-menus">
               <div class="mobile-menu-toggle">
-                <button>
+                <button aria-label="Show menu">
                   <admiralty-icon icon-name="bars"></admiralty-icon>
                 </button>
               </div>
@@ -67,7 +67,7 @@ describe('admiralty-header', () => {
             </div>
             <div class="header-menus">
               <div class="mobile-menu-toggle">
-                <button>
+                <button aria-label="Show menu">
                   <admiralty-icon icon-name="bars"></admiralty-icon>
                 </button>
               </div>
@@ -105,7 +105,7 @@ describe('admiralty-header', () => {
             </div>
             <div class="header-menus">
               <div class="mobile-menu-toggle">
-                <button>
+                <button aria-label="Show menu">
                   <admiralty-icon icon-name="bars"></admiralty-icon>
                 </button>
               </div>
@@ -146,7 +146,7 @@ describe('admiralty-header', () => {
             </div>
             <div class="header-menus">
               <div class="display-hamburger mobile-menu-toggle">
-                <button>
+                <button aria-label="Show menu">
                   <admiralty-icon icon-name="bars"></admiralty-icon>
                 </button>
               </div>
@@ -189,7 +189,7 @@ describe('admiralty-header', () => {
             </div>
             <div class="header-menus">
               <div class="display-hamburger mobile-menu-toggle">
-                <button>
+                <button aria-label="Show menu">
                   <admiralty-icon icon-name="bars"></admiralty-icon>
                 </button>
               </div>
@@ -233,7 +233,7 @@ describe('admiralty-header', () => {
             </div>
             <div class="header-menus">
               <div class="display-hamburger mobile-menu-toggle">
-                <button>
+                <button aria-label="Show menu">
                   <admiralty-icon icon-name="bars"></admiralty-icon>
                 </button>
               </div>
@@ -284,7 +284,7 @@ describe('admiralty-header', () => {
             </div>
             <div class="header-menus">
               <div class="display-hamburger mobile-menu-toggle">
-                <button>
+                <button aria-label="Show menu">
                   <admiralty-icon icon-name="bars"></admiralty-icon>
                 </button>
               </div>

--- a/packages/core/src/components/header/header.tsx
+++ b/packages/core/src/components/header/header.tsx
@@ -98,7 +98,7 @@ export class HeaderComponent {
           </div>
           <div class="header-menus">
             <div class={{ 'mobile-menu-toggle': true, 'display-hamburger': this.displayHamburger }}>
-              <button onClick={_ => this.toggleMobileMenu()} aria-expanded={this.mobileMenuOpen}>
+              <button onClick={_ => this.toggleMobileMenu()} aria-expanded={this.mobileMenuOpen} aria-label={this.mobileMenuOpen ? 'Hide menu' : 'Show menu'}>
                 <admiralty-icon icon-name={this.mobileMenuOpen ? faTimes.iconName : faBars.iconName}></admiralty-icon>
               </button>
             </div>

--- a/packages/core/src/components/skip-link/skip-link.scss
+++ b/packages/core/src/components/skip-link/skip-link.scss
@@ -1,16 +1,18 @@
-@use "../../scss/vars/colours";
-@use "../../scss/base/a11y";
+@use '../../scss/vars/colours';
+@use '../../scss/base/a11y';
 
 .skip-link {
   @extend .visually-hidden;
   color: colours.$colour-text;
   display: block;
   padding: 10px 15px;
+  box-shadow: none;
+
+  span {
+    box-shadow: 0 1px colours.$colour-text;
+  }
 
   &:focus {
-    outline: 3px solid colours.$colour-utility-focus;
-    outline-offset: 0;
-    background-color: colours.$colour-utility-focus;
     position: static !important;
     width: auto !important;
     height: auto !important;

--- a/packages/core/src/components/skip-link/skip-link.scss
+++ b/packages/core/src/components/skip-link/skip-link.scss
@@ -9,7 +9,7 @@
   box-shadow: none;
 
   span {
-    box-shadow: 0 1px colours.$colour-text;
+    box-shadow: 0 2px colours.$colour-text;
   }
 
   &:focus {

--- a/packages/core/src/components/skip-link/skip-link.spec.ts
+++ b/packages/core/src/components/skip-link/skip-link.spec.ts
@@ -10,7 +10,7 @@ describe('admiralty-link', () => {
     expect(root).toEqualHtml(`
       <admiralty-skip-link href="#main-content">
         <a class="skip-link" href="#main-content">
-          Skip to main content
+          <span>Skip to main content</span>
         </a>
       </admiralty-skip-link>
     `);

--- a/packages/core/src/components/skip-link/skip-link.tsx
+++ b/packages/core/src/components/skip-link/skip-link.tsx
@@ -14,7 +14,7 @@ export class SkipLinkComponent {
   render() {
     return (
       <a href={this.href} class="skip-link">
-        Skip to main content
+        <span>Skip to main content</span>
       </a>
     );
   }


### PR DESCRIPTION
Update focus states that were missed in [PR 248](https://github.com/UKHO/admiralty-design-system/pull/248)

Also updated all header text colours to match the Figma design.

<img width="829" alt="Screenshot 2024-09-16 at 15 10 23" src="https://github.com/user-attachments/assets/cd2e230b-4f22-4777-af1b-028a60b20549">
<img width="822" alt="Screenshot 2024-09-16 at 15 10 15" src="https://github.com/user-attachments/assets/ef2f6b83-2998-444e-bb24-9883029a7851">
<img width="824" alt="Screenshot 2024-09-16 at 15 10 42" src="https://github.com/user-attachments/assets/d6907dd2-3004-4048-93b9-2383d31a2d38">
<img width="824" alt="Screenshot 2024-09-16 at 15 10 53" src="https://github.com/user-attachments/assets/55847845-3a48-4eae-b20b-fa2b32e946a1">
<img width="829" alt="Screenshot 2024-09-16 at 15 11 26" src="https://github.com/user-attachments/assets/816c86f0-4ec3-47ed-be8e-6f43059703b6">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1--canary.254.8b34623.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@1.0.1--canary.254.8b34623.0
  npm install @ukho/admiralty-core@1.0.1--canary.254.8b34623.0
  # or 
  yarn add @ukho/admiralty-angular@1.0.1--canary.254.8b34623.0
  yarn add @ukho/admiralty-core@1.0.1--canary.254.8b34623.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
