### PR TITLE
Replace incorrect colour definition for info dialogue

### DIFF
--- a/packages/core/src/themes/default.css
+++ b/packages/core/src/themes/default.css
@@ -58,7 +58,7 @@
   --admiralty-colour-info-contrast-rgb: 255, 255, 255;
   --admiralty-colour-info-shade: #0169aa;
   --admiralty-colour-info-tint: #1a85c7;
-  --admiralty-colour-info-background: #e0ecd3;
+  --admiralty-colour-info-background: #e0ecf3;
 
   /** light **/
   --admiralty-colour-light: #d8d8d8;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.265.91e8ce6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@2.0.0--canary.265.91e8ce6.0
  npm install @ukho/admiralty-core@2.0.0--canary.265.91e8ce6.0
  # or 
  yarn add @ukho/admiralty-angular@2.0.0--canary.265.91e8ce6.0
  yarn add @ukho/admiralty-core@2.0.0--canary.265.91e8ce6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
