### PR TITLE
fix: Header sub menu items should be links

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -514,14 +514,14 @@ the sign in button
 
 
 @ProxyCmp({
-  inputs: ['menuTitle']
+  inputs: ['href', 'menuTitle', 'suppressRedirect']
 })
 @Component({
   selector: 'admiralty-header-sub-menu-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['menuTitle'],
+  inputs: ['href', 'menuTitle', 'suppressRedirect'],
 })
 export class AdmiraltyHeaderSubMenuItem {
   protected el: HTMLElement;
@@ -535,7 +535,7 @@ export class AdmiraltyHeaderSubMenuItem {
 
 export declare interface AdmiraltyHeaderSubMenuItem extends Components.AdmiraltyHeaderSubMenuItem {
   /**
-   * The event that is fired when a user clicks on the menu.
+   * The event that is fired when a user clicks on the menu item.
 Event contains the menu item text.
    */
   subMenuItemClick: EventEmitter<CustomEvent<string>>;

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -380,9 +380,17 @@ export namespace Components {
     }
     interface AdmiraltyHeaderSubMenuItem {
         /**
+          * The URL to link to.
+         */
+        "href": string;
+        /**
           * The text that will be displayed in the menu
          */
         "menuTitle": string;
+        /**
+          * Causes the default browser redirect to be suppressed. Can be used in conjunction with the `onMenuItemClick` event to use a navigation router and prevent a full page reload when navigating.
+         */
+        "suppressRedirect"?: boolean;
     }
     interface AdmiraltyHint {
         /**
@@ -1893,13 +1901,21 @@ declare namespace LocalJSX {
     }
     interface AdmiraltyHeaderSubMenuItem {
         /**
+          * The URL to link to.
+         */
+        "href"?: string;
+        /**
           * The text that will be displayed in the menu
          */
         "menuTitle"?: string;
         /**
-          * The event that is fired when a user clicks on the menu. Event contains the menu item text.
+          * The event that is fired when a user clicks on the menu item. Event contains the menu item text.
          */
         "onSubMenuItemClick"?: (event: AdmiraltyHeaderSubMenuItemCustomEvent<string>) => void;
+        /**
+          * Causes the default browser redirect to be suppressed. Can be used in conjunction with the `onMenuItemClick` event to use a navigation router and prevent a full page reload when navigating.
+         */
+        "suppressRedirect"?: boolean;
     }
     interface AdmiraltyHint {
         /**

--- a/packages/core/src/components/header-profile/header-profile.spec.ts
+++ b/packages/core/src/components/header-profile/header-profile.spec.ts
@@ -67,12 +67,12 @@ describe('header-profile', () => {
               </div>
             </div>
             <div class="not-desktop">
-              <button class="sub-menu-item" tabindex="0">
+              <button class="sub-menu-item">
                 <span>
                   Your Account
                 </span>
               </button>
-              <button class="sub-menu-item" tabindex="0">
+              <button class="sub-menu-item">
                 <span>
                   Sign Out
                 </span>

--- a/packages/core/src/components/header-profile/header-profile.tsx
+++ b/packages/core/src/components/header-profile/header-profile.tsx
@@ -101,10 +101,10 @@ export class HeaderProfileComponent {
               </div>
               {!signInOnly ? (
                 <div class="not-desktop">
-                  <button class="sub-menu-item" onClick={this.handleYourAccount} tabindex="0">
+                  <button class="sub-menu-item" onClick={this.handleYourAccount}>
                     <span>Your Account</span>
                   </button>
-                  <button class="sub-menu-item" onClick={this.handleSignOut} tabindex="0">
+                  <button class="sub-menu-item" onClick={this.handleSignOut}>
                     <span>Sign Out</span>
                   </button>
                 </div>

--- a/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.e2e.ts
+++ b/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.e2e.ts
@@ -13,7 +13,7 @@ describe('menu-item', () => {
     const page = await newE2EPage();
     await page.setContent('<admiralty-header-sub-menu-item menuTitle="Item 1"></admiralty-header-sub-menu-item>');
 
-    const element = await page.find('div.header-sub-menu-item');
+    const element = await page.find('button.header-sub-menu-item');
 
     const eventSpy = await page.spyOnEvent('subMenuItemClick');
 

--- a/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.scss
+++ b/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.scss
@@ -12,6 +12,10 @@
     font-weight: $header-sub-menu-item-text-weight;
   }
 
+  a {
+    text-decoration: none;
+  }
+
   &:focus {
     outline: none;
 
@@ -55,9 +59,7 @@
 
     &:focus {
       .title {
-        box-shadow:
-          0 -4px $header-sub-menu-item-focus-colour,
-          0 4px $header-sub-menu-item-text-colour;
+        box-shadow: 0 -4px $header-sub-menu-item-focus-colour, 0 4px $header-sub-menu-item-text-colour;
       }
     }
   }

--- a/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.spec.ts
+++ b/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.spec.ts
@@ -9,9 +9,9 @@ describe('header-sub-menu-item', () => {
     });
     expect(page.root).toEqualHtml(`
       <admiralty-header-sub-menu-item menutitle="Item 1">
-        <div class="header-sub-menu-item" tabindex="0">
+        <button class="header-sub-menu-item">
           <span class="title"></span>
-        </div>
+        </button>
       </admiralty-header-sub-menu-item>
     `);
   });

--- a/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.spec.ts
+++ b/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.spec.ts
@@ -15,4 +15,92 @@ describe('header-sub-menu-item', () => {
       </admiralty-header-sub-menu-item>
     `);
   });
+
+  it('renders a link when a value is supplied for href', async () => {
+    const page = await newSpecPage({
+      components: [HeaderSubMenuItemComponent],
+      html: `<admiralty-header-sub-menu-item menuTitle="Item 1" href="/test"></slot></admiralty-header-sub-menu-item>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <admiralty-header-sub-menu-item menutitle="Item 1" href="/test">
+        <div class="header-sub-menu-item">
+          <a class="title" href="/test"></a>
+        </div>
+      </admiralty-header-sub-menu-item>
+    `);
+  });
+
+  it('emits an event when the link is clicked', async () => {
+    const page = await newSpecPage({
+      components: [HeaderSubMenuItemComponent],
+      html: `<admiralty-header-sub-menu-item href="/test">Test</admiralty-header-sub-menu-item>`,
+    });
+
+    const eventSpy = jest.fn();
+    page.doc.addEventListener('subMenuItemClick', eventSpy);
+
+    const link = page.doc.querySelector('admiralty-header-sub-menu-item a');
+    link.dispatchEvent(new Event('click'));
+
+    await page.waitForChanges();
+
+    expect(eventSpy).toHaveBeenCalled();
+  });
+
+  it('emits an event when the div is clicked', async () => {
+    const page = await newSpecPage({
+      components: [HeaderSubMenuItemComponent],
+      html: `<admiralty-header-sub-menu-item href="/test">Test</admiralty-header-sub-menu-item>`,
+    });
+
+    const eventSpy = jest.fn();
+    page.doc.addEventListener('subMenuItemClick', eventSpy);
+
+    const link = page.doc.querySelector('admiralty-header-sub-menu-item div.header-sub-menu-item');
+    link.dispatchEvent(new Event('click'));
+
+    await page.waitForChanges();
+
+    expect(eventSpy).toHaveBeenCalled();
+  });
+
+  it('prevents default event when the link is clicked', async () => {
+    const page = await newSpecPage({
+      components: [HeaderSubMenuItemComponent],
+      html: `<admiralty-header-sub-menu-item href="/test" suppress-redirect="true">Test</admiralty-header-sub-menu-item>`,
+    });
+
+    const eventSpy = jest.fn();
+    page.doc.addEventListener('subMenuItemClick', eventSpy);
+
+    const link = page.doc.querySelector('admiralty-header-sub-menu-item a');
+    const event = new Event('click');
+    Object.assign(event, { preventDefault: jest.fn() });
+    link.dispatchEvent(event);
+
+    await page.waitForChanges();
+
+    expect(eventSpy).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('does not emit the default event when the link is clicked', async () => {
+    const page = await newSpecPage({
+      components: [HeaderSubMenuItemComponent],
+      html: `<admiralty-header-sub-menu-item href="/test" suppress-redirect="false">Test</admiralty-header-sub-menu-item>`,
+    });
+
+    const eventSpy = jest.fn();
+    page.doc.addEventListener('subMenuItemClick', eventSpy);
+
+    const link = page.doc.querySelector('admiralty-header-sub-menu-item a');
+    const event = new Event('click');
+    Object.assign(event, { preventDefault: jest.fn() });
+    link.dispatchEvent(event);
+
+    await page.waitForChanges();
+
+    expect(eventSpy).toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.tsx
+++ b/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.tsx
@@ -38,12 +38,6 @@ export class HeaderSubMenuItemComponent {
     return this.subMenuItemClick.emit(this.menuTitle);
   }
 
-  onKeyDown(ev: KeyboardEvent): void {
-    if (ev.key === Keys.ENTER || ev.key === Keys.SPACE) {
-      this.subMenuItemClick.emit(this.menuTitle);
-    }
-  }
-
   render() {
     return (
       <Host>
@@ -55,9 +49,9 @@ export class HeaderSubMenuItemComponent {
             </a>
           </div>
         ) : (
-          <div class="header-sub-menu-item" onClick={ev => this.handleClick(ev)} onKeyDown={ev => this.onKeyDown(ev)} tabindex="0">
+          <button class="header-sub-menu-item" onClick={ev => this.handleClick(ev)}>
             <span class="title">{this.menuTitle}</span>
-          </div>
+          </button>
         )}
       </Host>
     );

--- a/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.tsx
+++ b/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.tsx
@@ -13,15 +13,30 @@ export class HeaderSubMenuItemComponent {
   @Prop() menuTitle: string;
 
   /**
-   * The event that is fired when a user clicks on the menu.
+   * The URL to link to.
+   */
+  @Prop() href: string;
+
+  /**
+   * Causes the default browser redirect to be suppressed. Can be used in conjunction with the
+   * `onMenuItemClick` event to use a navigation router and prevent a full page reload when navigating.
+   */
+  @Prop() suppressRedirect?: boolean = false;
+
+  /**
+   * The event that is fired when a user clicks on the menu item.
    * Event contains the menu item text.
    */
   @Event() subMenuItemClick: EventEmitter<string>;
 
   handleClick(ev: MouseEvent): CustomEvent<string> {
+    if (this.suppressRedirect) {
+      ev.preventDefault();
+    }
     ev.stopPropagation();
+
     return this.subMenuItemClick.emit(this.menuTitle);
-  };
+  }
 
   onKeyDown(ev: KeyboardEvent): void {
     if (ev.key === Keys.ENTER || ev.key === Keys.SPACE) {
@@ -32,11 +47,19 @@ export class HeaderSubMenuItemComponent {
   render() {
     return (
       <Host>
-        <div class="header-sub-menu-item" onClick={ev=>this.handleClick(ev)} onKeyDown={ev=>this.onKeyDown(ev)} tabindex="0">
-          <span class="title">{this.menuTitle}</span>
-        </div>
+        {this.href ? (
+          <div class="header-sub-menu-item" onClick={ev => this.handleClick(ev)}>
+            <a class="title" href={this.href} onClick={ev => this.handleClick(ev)}>
+              {this.menuTitle}
+              <slot></slot>
+            </a>
+          </div>
+        ) : (
+          <div class="header-sub-menu-item" onClick={ev => this.handleClick(ev)} onKeyDown={ev => this.onKeyDown(ev)} tabindex="0">
+            <span class="title">{this.menuTitle}</span>
+          </div>
+        )}
       </Host>
     );
   }
-
 }

--- a/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.tsx
+++ b/packages/core/src/components/header-sub-menu-item/header-sub-menu-item.tsx
@@ -1,5 +1,4 @@
 import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
-import { Keys } from '../Keys';
 
 @Component({
   tag: 'admiralty-header-sub-menu-item',

--- a/packages/core/src/components/header-sub-menu-item/readme.md
+++ b/packages/core/src/components/header-sub-menu-item/readme.md
@@ -7,16 +7,18 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                                 | Type     | Default     |
-| ----------- | ------------ | ------------------------------------------- | -------- | ----------- |
-| `menuTitle` | `menu-title` | The text that will be displayed in the menu | `string` | `undefined` |
+| Property           | Attribute           | Description                                                                                                                                                                                  | Type      | Default     |
+| ------------------ | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `href`             | `href`              | The URL to link to.                                                                                                                                                                          | `string`  | `undefined` |
+| `menuTitle`        | `menu-title`        | The text that will be displayed in the menu                                                                                                                                                  | `string`  | `undefined` |
+| `suppressRedirect` | `suppress-redirect` | Causes the default browser redirect to be suppressed. Can be used in conjunction with the `onMenuItemClick` event to use a navigation router and prevent a full page reload when navigating. | `boolean` | `false`     |
 
 
 ## Events
 
-| Event              | Description                                                                                | Type                  |
-| ------------------ | ------------------------------------------------------------------------------------------ | --------------------- |
-| `subMenuItemClick` | The event that is fired when a user clicks on the menu. Event contains the menu item text. | `CustomEvent<string>` |
+| Event              | Description                                                                                     | Type                  |
+| ------------------ | ----------------------------------------------------------------------------------------------- | --------------------- |
+| `subMenuItemClick` | The event that is fired when a user clicks on the menu item. Event contains the menu item text. | `CustomEvent<string>` |
 
 
 ----------------------------------------------

--- a/packages/core/src/components/header/header.stories.data.ts
+++ b/packages/core/src/components/header/header.stories.data.ts
@@ -7,15 +7,18 @@ export const mockMenuItemsWithSubItems: HeaderItem[] = [
     subitems: [
       {
         title: 'sub item 1',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
       {
         title: 'Super long sub navigation item for wrapping',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
       {
         title: 'sub item 3',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
     ],
   },
@@ -24,11 +27,12 @@ export const mockMenuItemsWithSubItems: HeaderItem[] = [
     subitems: [
       {
         title: 'sub item 1',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
       {
         title: 'sub item 2',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
       },
     ],
   },
@@ -37,7 +41,8 @@ export const mockMenuItemsWithSubItems: HeaderItem[] = [
     subitems: [
       {
         title: 'sub item 1',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
     ],
   },
@@ -49,15 +54,18 @@ export const mockMenuItemsWithSubItemsAndNavActive: HeaderItem[] = [
     subitems: [
       {
         title: 'sub item 1',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
       {
         title: 'Super long sub navigation item for wrapping',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
       {
         title: 'sub item 3',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
     ],
   },
@@ -67,11 +75,12 @@ export const mockMenuItemsWithSubItemsAndNavActive: HeaderItem[] = [
     subitems: [
       {
         title: 'sub item 1',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
       {
         title: 'sub item 2',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
       },
     ],
   },
@@ -80,7 +89,8 @@ export const mockMenuItemsWithSubItemsAndNavActive: HeaderItem[] = [
     subitems: [
       {
         title: 'sub item 1',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
     ],
   },
@@ -92,28 +102,33 @@ export const mockMenuItemsWithSomeSubItems: HeaderItem[] = [
     subitems: [
       {
         title: 'sub item 1',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
       {
         title: 'sub item 2',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
       {
         title: 'sub item 3',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
     ],
   },
   {
     title: 'Item 2',
-    clickAction:action('item clicked'),
+    clickAction: action('item clicked'),
+    href: 'http://www.example.com',
   },
   {
     title: 'Item 3',
     subitems: [
       {
         title: 'sub item 1',
-        clickAction:action('sub item clicked'),
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
       },
     ],
   },
@@ -122,30 +137,79 @@ export const mockMenuItemsWithSomeSubItems: HeaderItem[] = [
 export const mockMenuItemsWithNoSubItems: HeaderItem[] = [
   {
     title: 'Item 1',
-    clickAction:action('item clicked'),
+    clickAction: action('item clicked'),
+    href: 'http://www.example.com',
   },
   {
     title: 'Item 2',
-    clickAction:action('item clicked'),
+    clickAction: action('item clicked'),
+    href: 'http://www.example.com',
   },
   {
     title: 'Item 3',
-    clickAction:action('item clicked'),
+    clickAction: action('item clicked'),
+    href: 'http://www.example.com',
   },
 ];
 
 export const mockMenuItemsWithNoSubItemsAndNavActive: HeaderItem[] = [
   {
     title: 'Item 1',
-    clickAction:action('item clicked'),
+    clickAction: action('item clicked'),
+    href: 'http://www.example.com',
   },
   {
     title: 'Item 2',
     navActive: true,
-    clickAction:action('item clicked'),
+    clickAction: action('item clicked'),
+    href: 'http://www.example.com',
   },
   {
     title: 'Item 3',
-    clickAction:action('item clicked'),
+    clickAction: action('item clicked'),
+    href: 'http://www.example.com',
+  },
+];
+
+export const mockMenuItemsWithRedirectNotSuppressed: HeaderItem[] = [
+  {
+    title: 'Item 1',
+    subitems: [
+      {
+        title: 'sub item 1',
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
+        suppressRedirect: false,
+      },
+      {
+        title: 'sub item 2',
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
+        suppressRedirect: false,
+      },
+      {
+        title: 'sub item 3',
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
+        suppressRedirect: false,
+      },
+    ],
+  },
+  {
+    title: 'Item 2',
+    clickAction: action('item clicked'),
+    href: 'http://www.example.com',
+    suppressRedirect: false,
+  },
+  {
+    title: 'Item 3',
+    subitems: [
+      {
+        title: 'sub item 1',
+        clickAction: action('sub item clicked'),
+        href: 'http://www.example.com',
+        suppressRedirect: false,
+      },
+    ],
   },
 ];

--- a/packages/core/src/components/header/header.stories.ts
+++ b/packages/core/src/components/header/header.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/web-components';
+import { withActions } from '@storybook/addon-actions/decorator';
 import { HeaderComponent } from './header';
 import { html } from 'lit';
 import {
@@ -7,8 +8,10 @@ import {
   mockMenuItemsWithNoSubItems,
   mockMenuItemsWithSubItemsAndNavActive,
   mockMenuItemsWithNoSubItemsAndNavActive,
+  mockMenuItemsWithRedirectNotSuppressed,
 } from './header.stories.data';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { HeaderItem, HeaderSubItem } from './header.types';
 
 const meta: Meta = {
   component: 'admiralty-header',
@@ -18,18 +21,56 @@ const meta: Meta = {
       handles: ['titledClicked', 'menuItemClick', 'subMenuItemClick', 'signInClicked', 'yourAccountClicked', 'signOutClicked'],
     },
   },
+  decorators: [withActions],
 };
 
 export default meta;
 
-type Story = StoryObj<HeaderComponent>;
+type HeaderComponentArgs = Partial<
+  HeaderComponent & {
+    title: string;
+    signedIn: boolean;
+    singedInText: string;
+    signInOnly: boolean;
+    menuItems: HeaderItem[];
+    showProfileMenu: boolean;
+  }
+>;
+
+type Story = StoryObj<HeaderComponentArgs>;
+
+const renderMenuItems = (menuItems: HeaderItem[] | undefined) =>
+  menuItems
+    ?.map(({ title, navActive = false, href, suppressRedirect = true, subitems }) => {
+      if (href !== undefined) {
+        return `<admiralty-header-menu-link menu-title="${title}" active="${navActive}" slot="items" href="${href}" suppress-redirect="${suppressRedirect}"></admiralty-header-menu-link>`;
+      }
+      return `<admiralty-header-menu-item menu-title="${title}" active="${navActive}" slot="items">
+          ${renderSubMenuItems(subitems)}
+        </admiralty-header-menu-item>`;
+    })
+    .join('');
+
+const renderSubMenuItems = (subMenuItems: HeaderSubItem[] | undefined) =>
+  subMenuItems
+    ?.map(
+      ({ title, href = '', suppressRedirect = true }) => `<admiralty-header-sub-menu-item menu-title="${title}" href="${href}" suppress-redirect="${suppressRedirect}">
+          </admiralty-header-sub-menu-item>`,
+    )
+    .join('');
+
+const renderProfileMenu = ({ showProfileMenu, signedIn, singedInText, signInOnly }: HeaderComponentArgs) =>
+  showProfileMenu
+    ? `<admiralty-header-profile is-signed-in="${signedIn}" signed-in-text="${singedInText}" sign-in-only="${signInOnly}" slot="profile"></admiralty-header-profile>`
+    : '';
 
 const defaultArgs = {
-  title: 'Design System',
-  titleLinkUrl: 'http://www.example.com',
+  headerTitle: 'Design System',
+  headerTitleUrl: 'http://www.example.com',
   logoAltText: 'ADMIRALTY',
   logoImgUrl: 'svg/Admiralty stacked logo.svg',
   logoLinkUrl: 'http://www.example.com',
+  showProfileMenu: true,
 };
 
 const profileArgs = {
@@ -38,60 +79,21 @@ const profileArgs = {
   signInOnly: false,
 };
 
-const TemplateSignedOut: Story = {
+const Template: Story = {
   render: args =>
     html` <admiralty-header
       logo-alt-text="${args.logoAltText}"
       logo-link-url="${args.logoLinkUrl}"
       logo-img-url="${args.logoImgUrl}"
-      header-title-url="#"
-      header-title="${args.title}"
+      header-title-url="${args.headerTitleUrl}"
+      header-title="${args.headerTitle}"
     >
-      <admiralty-header-profile is-signed-in="${args.signedIn}" signed-in-text="${args.singedInText}" sign-in-only="${args.signInOnly}" slot="profile"></admiralty-header-profile>
+      ${unsafeHTML(renderMenuItems(args.menuItems))} ${unsafeHTML(renderProfileMenu(args))}
     </admiralty-header>`,
 };
 
-const TemplateLinksAndAuth: Story = {
-  render: args => {
-    const menuItems = args.menuItems.map(item => {
-      const subItems = item.subitems?.map(si => `<admiralty-header-sub-menu-item menu-title="${si.title}"></admiralty-header-sub-menu-item>`);
-      return `<admiralty-header-menu-item menu-title="${item.title}" active="${item.navActive ?? false}" slot="items">${subItems?.join('')}</admiralty-header-menu-item>
-    `;
-    });
-
-    let template = `<admiralty-header logo-alt-text="${args.logoAltText}" logo-link-url="${args.logoLinkUrl}" logo-img-url="${
-      args.logoImgUrl
-    }" header-title-url="#" header-title="${args.title}">
-      ${menuItems?.join('')}
-      <admiralty-header-profile is-signed-in="${args.signedIn}" signed-in-text="${args.singedInText}" slot="profile"></admiralty-header-profile>
-    </admiralty-header>`;
-
-    return html`${unsafeHTML(template)}`;
-  },
-};
-
-const TemplateLinksNoAuth: Story = {
-  render: args => {
-    const menuItems = args.menuItems?.map(item => {
-      const subItems = item.subitems?.map(si => `<admiralty-header-sub-menu-item menu-title="${si.title}"></admiralty-header-sub-menu-item>`);
-      return subItems?.length > 0
-        ? `<admiralty-header-menu-item menu-title="${item.title}" active="${item.navActive ?? false}" slot="items">${subItems?.join('') ?? ''}</admiralty-header-menu-item>`
-        : `<admiralty-header-menu-link menu-title="${item.title}" href="${item.href ?? ''}" suppress-redirect="true" active="${item.navActive ?? false}" slot="items">${subItems?.join('') ?? ''}</admiralty-header-menu-link>
-      `;
-    });
-
-    let template = `<admiralty-header logo-alt-text="${args.logoAltText}" logo-link-url="${args.logoLinkUrl}" logo-img-url="${
-      args.logoImgUrl
-    }" header-title-url="#" header-title="${args.title}">
-      ${menuItems?.join('') ?? ''}
-    </admiralty-header>`;
-
-    return html`${unsafeHTML(template)}`;
-  },
-};
-
 export const linksAndAuthNotSignedIn: Story = {
-  ...TemplateLinksAndAuth,
+  ...Template,
   args: {
     menuItems: mockMenuItemsWithSubItems,
     ...defaultArgs,
@@ -100,48 +102,53 @@ export const linksAndAuthNotSignedIn: Story = {
 };
 
 export const linksWithNoSubItems: Story = {
-  ...TemplateLinksNoAuth,
+  ...Template,
   args: {
-    menuItems: mockMenuItemsWithNoSubItems,
     ...defaultArgs,
+    menuItems: mockMenuItemsWithNoSubItems,
+    showProfileMenu: false,
     logoImgUrl: 'svg/UKHO linear logo.svg',
   },
 };
 
 export const linksWithNoSubItemsAndNavActive: Story = {
-  ...TemplateLinksNoAuth,
+  ...Template,
   args: {
-    menuItems: mockMenuItemsWithNoSubItemsAndNavActive,
     ...defaultArgs,
+    menuItems: mockMenuItemsWithNoSubItemsAndNavActive,
+    showProfileMenu: false,
   },
 };
 
 export const linksWithSubItemsAndNavActive: Story = {
-  ...TemplateLinksNoAuth,
+  ...Template,
   args: {
-    menuItems: mockMenuItemsWithSubItemsAndNavActive,
     ...defaultArgs,
+    menuItems: mockMenuItemsWithSubItemsAndNavActive,
+    showProfileMenu: false,
   },
 };
 
 export const linksWithSomeSubItems: Story = {
-  ...TemplateLinksNoAuth,
+  ...Template,
   args: {
-    menuItems: mockMenuItemsWithSomeSubItems,
     ...defaultArgs,
+    menuItems: mockMenuItemsWithSomeSubItems,
+    showProfileMenu: false,
   },
 };
 
 export const noLinks: Story = {
-  render: args => html` <admiralty-header header-title="${args.title}" logo-link-url="${args.logoLinkUrl}" headerTitleUrl="${args.titleLinkUrl}"> </admiralty-header>`,
+  ...Template,
   args: {
     ...defaultArgs,
-    titleLinkUrl: null,
+    headerTitleUrl: undefined,
+    showProfileMenu: false,
   },
 };
 
 export const HeaderSignedIn: Story = {
-  ...TemplateSignedOut,
+  ...Template,
   args: {
     ...defaultArgs,
     ...profileArgs,
@@ -150,9 +157,18 @@ export const HeaderSignedIn: Story = {
 };
 
 export const HeaderSignedOut: Story = {
-  ...TemplateSignedOut,
+  ...Template,
   args: {
     ...defaultArgs,
     ...profileArgs,
+  },
+};
+
+export const linksWithRedirectNotSuppressed: Story = {
+  ...Template,
+  args: {
+    ...defaultArgs,
+    menuItems: mockMenuItemsWithRedirectNotSuppressed,
+    showProfileMenu: false,
   },
 };

--- a/packages/core/src/components/header/header.types.ts
+++ b/packages/core/src/components/header/header.types.ts
@@ -3,9 +3,13 @@ export interface HeaderItem {
   clickAction?: () => any;
   navActive?: boolean;
   subitems?: HeaderSubItem[];
+  href?: string;
+  suppressRedirect?: boolean;
 }
 
 export interface HeaderSubItem {
   title: string;
   clickAction: () => any;
+  href?: string;
+  suppressRedirect?: boolean;
 }

--- a/packages/core/src/components/side-nav-item/side-nav-item.spec.ts
+++ b/packages/core/src/components/side-nav-item/side-nav-item.spec.ts
@@ -9,7 +9,7 @@ describe('admiralty-side-nav-item', () => {
     });
     expect(root).toEqualHtml(`
       <admiralty-side-nav-item>
-        <a class="section" role="button" tabindex="0"></a>
+        <a class="section"></a>
       </admiralty-side-nav-item>
     `);
   });

--- a/packages/core/src/components/side-nav-item/side-nav-item.tsx
+++ b/packages/core/src/components/side-nav-item/side-nav-item.tsx
@@ -50,8 +50,6 @@ export class SideNavItemComponent {
           section: true,
           navActive: this.navActive,
         }}
-        tabindex="0"
-        role="button"
         onClick={this.handleClickAction.bind(this)}
         onKeyUp={this.handleKeyUpAction.bind(this)}
       >

--- a/packages/core/src/components/side-nav/side-nav.spec.ts
+++ b/packages/core/src/components/side-nav/side-nav.spec.ts
@@ -38,7 +38,7 @@ describe('admiralty-side-nav', () => {
       <admiralty-side-nav>
         <nav class="side-nav">
           <admiralty-side-nav-item>
-            <a class="section" role="button" tabindex="0"></a>
+            <a class="section"></a>
           </admiralty-side-nav-item>
         </nav>
       </admiralty-side-nav>
@@ -58,13 +58,13 @@ describe('admiralty-side-nav', () => {
       <admiralty-side-nav>
         <nav class="side-nav">
           <admiralty-side-nav-item>
-            <a class="section" role="button" tabindex="0"></a>
+            <a class="section"></a>
           </admiralty-side-nav-item>
           <admiralty-side-nav-item>
-            <a class="section" role="button" tabindex="0"></a>
+            <a class="section"></a>
           </admiralty-side-nav-item>
           <admiralty-side-nav-item>
-            <a class="section" role="button" tabindex="0"></a>
+            <a class="section"></a>
           </admiralty-side-nav-item>
         </nav>
       </admiralty-side-nav>

--- a/packages/website/src/app/components/header/header.mdx
+++ b/packages/website/src/app/components/header/header.mdx
@@ -16,6 +16,10 @@ import Basic from "@/usage/header/basic/index.mdx";
 
 Use menu items and sub items to allow users to navigate the site. Active states let them know which page they are on.
 
+Menu items should include a URL value for the `href` prop so that the component can render a functional link, allowing users to navigate to the specified destination when they click on the menu item. The exception is when the menu item contains sub menu items.
+
+When a navigation router is being used, for instance in Angular or React, the default browser redirect can be suppressed. The `onMenuItemClick` event can then be used to call the framework's navigation function, which will prevent a full page reload when navigating between pages.
+
 import MenuItem from "@/usage/header/menu-item/index.mdx";
 
 <MenuItem />

--- a/packages/website/src/usage/header/menu-item/angular.mdx
+++ b/packages/website/src/usage/header/menu-item/angular.mdx
@@ -7,21 +7,17 @@
   header-title="Design System"
 >
   <admiralty-header-menu-item menu-title="Item 1" active="false" slot="items">
-    <admiralty-header-sub-menu-item menu-title="sub item 1"></admiralty-header-sub-menu-item>
+    <admiralty-header-sub-menu-item menu-title="sub item 1" href="/item-1-1"></admiralty-header-sub-menu-item>
     <admiralty-header-sub-menu-item
       menu-title="Super long sub navigation item for wrapping"
+      href="/item-1-2"
     ></admiralty-header-sub-menu-item>
-    <admiralty-header-sub-menu-item menu-title="sub item 3"></admiralty-header-sub-menu-item>
+    <admiralty-header-sub-menu-item menu-title="sub item 3" href="/item-1-3"></admiralty-header-sub-menu-item>
   </admiralty-header-menu-item>
-  <admiralty-header-menu-link
-    menu-title="Item 2"
-    active="false"
-    href="/components/header"
-    suppress-redirect="true"
-    slot="items">
+  <admiralty-header-menu-link menu-title="Item 2" active="false" href="/item-2" suppress-redirect="true" slot="items">
   </admiralty-header-menu-link>
   <admiralty-header-menu-item menu-title="Item 3" active="false" slot="items">
-    <admiralty-header-sub-menu-item menu-title="sub item 1"></admiralty-header-sub-menu-item>
+    <admiralty-header-sub-menu-item menu-title="sub item 1" href="/item-3-1"></admiralty-header-sub-menu-item>
   </admiralty-header-menu-item>
   <admiralty-header-profile is-signed-in="false" signed-in-text="Mr Admiral" slot="profile"></admiralty-header-profile>
 </admiralty-header>

--- a/packages/website/src/usage/header/menu-item/javascript.mdx
+++ b/packages/website/src/usage/header/menu-item/javascript.mdx
@@ -7,21 +7,17 @@
   header-title="Design System"
 >
   <admiralty-header-menu-item menu-title="Item 1" active="false" slot="items">
-    <admiralty-header-sub-menu-item menu-title="sub item 1"></admiralty-header-sub-menu-item>
+    <admiralty-header-sub-menu-item menu-title="sub item 1" href="/item-1-1"></admiralty-header-sub-menu-item>
     <admiralty-header-sub-menu-item
       menu-title="Super long sub navigation item for wrapping"
+      href="/item-1-2"
     ></admiralty-header-sub-menu-item>
-    <admiralty-header-sub-menu-item menu-title="sub item 3"></admiralty-header-sub-menu-item>
+    <admiralty-header-sub-menu-item menu-title="sub item 3" href="/item-1-3"></admiralty-header-sub-menu-item>
   </admiralty-header-menu-item>
-  <admiralty-header-menu-link
-    menu-title="Item 2"
-    active="false"
-    href="/components/header"
-    suppress-redirect="true"
-    slot="items">
+  <admiralty-header-menu-link menu-title="Item 2" active="false" href="/item-2" suppress-redirect="true" slot="items">
   </admiralty-header-menu-link>
   <admiralty-header-menu-item menu-title="Item 3" active="false" slot="items">
-    <admiralty-header-sub-menu-item menu-title="sub item 1"></admiralty-header-sub-menu-item>
+    <admiralty-header-sub-menu-item menu-title="sub item 1" href="/item-3-1"></admiralty-header-sub-menu-item>
   </admiralty-header-menu-item>
   <admiralty-header-profile is-signed-in="false" signed-in-text="Mr Admiral" slot="profile"></admiralty-header-profile>
 </admiralty-header>

--- a/packages/website/src/usage/header/menu-item/react.mdx
+++ b/packages/website/src/usage/header/menu-item/react.mdx
@@ -6,19 +6,20 @@
   header-title-url="#"
   header-title="Design System">
   <AdmiraltyHeaderMenuItem menu-title="Item 1" active={false} slot="items">
-    <AdmiraltyHeaderSubMenuItem menu-title="sub item 1"></AdmiraltyHeaderSubMenuItem>
-    <AdmiraltyHeaderSubMenuItem menu-title="Super long sub navigation item for wrapping"></AdmiraltyHeaderSubMenuItem>
-    <AdmiraltyHeaderSubMenuItem menu-title="sub item 3"></AdmiraltyHeaderSubMenuItem>
+    <AdmiraltyHeaderSubMenuItem menu-title="sub item 1" href="/item-1-1"></AdmiraltyHeaderSubMenuItem>
+    <AdmiraltyHeaderSubMenuItem
+      menu-title="Super long sub navigation item for wrapping"
+      href="/item-1-2"></AdmiraltyHeaderSubMenuItem>
+    <AdmiraltyHeaderSubMenuItem menu-title="sub item 3" href="/item-1-3"></AdmiraltyHeaderSubMenuItem>
   </AdmiraltyHeaderMenuItem>
   <AdmiraltyHeaderMenuLink
     menu-title="Item 2"
     active={false}
-    href="/components/header"
+    href="/item-2"
     suppress-redirect={true}
-    slot="items">
-  </AdmiraltyHeaderMenuLink>
+    slot="items"></AdmiraltyHeaderMenuLink>
   <AdmiraltyHeaderMenuItem menu-title="Item 3" active={false} slot="items">
-    <AdmiraltyHeaderSubMenuItem menu-title="sub item 1"></AdmiraltyHeaderSubMenuItem>
+    <AdmiraltyHeaderSubMenuItem menu-title="sub item 1" href="/item-3-1"></AdmiraltyHeaderSubMenuItem>
   </AdmiraltyHeaderMenuItem>
   <AdmiraltyHeaderProfile is-signed-in={false} signed-in-text="Mr Admiral" slot="profile"></AdmiraltyHeaderProfile>
 </AdmiraltyHeader>


### PR DESCRIPTION
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/8ce9df79-22a7-44b1-8079-c664df07bb0b">

Sub menu items were being rendered as `<div>` tags with event listeners. This goes against best practice.

Menu items in the Header component should be rendered as buttons or links. If the menu opens another menu the item should be a button. If the item redirect the user to another page then it should be a link.

When the `href` property is supplied to the `HeaderSubMenuItemComponent` it will now render an `<a>` tag.

The correct structure for a menu is:

```html
<admiralty-header>
  <admiralty-header-menu-item menu-title="Item 1" slot="items">
    <admiralty-header-sub-menu-item menu-title="Sub menu item 1" href="/item-1-1" />
    <admiralty-header-sub-menu-item menu-title="Sub menu item 2" href="/item-1-2" />
  </admiralty-header-menu-item>
  <admiralty-header-menu-link menu-title="Item 2" href="/item-2" slot="items" />  
  <admiralty-header-profile slot="profile"/>
</admiralty-header>
```


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.270.08d2d72.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@2.0.0--canary.270.08d2d72.0
  npm install @ukho/admiralty-core@2.0.0--canary.270.08d2d72.0
  npm install @ukho/admiralty-react@2.0.0--canary.270.08d2d72.0
  # or 
  yarn add @ukho/admiralty-angular@2.0.0--canary.270.08d2d72.0
  yarn add @ukho/admiralty-core@2.0.0--canary.270.08d2d72.0
  yarn add @ukho/admiralty-react@2.0.0--canary.270.08d2d72.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
