### PR TITLE
Feat: Include documentation to demonstrate a placeholder option

### DIFF
--- a/packages/core/src/components/select/select.spec.ts
+++ b/packages/core/src/components/select/select.spec.ts
@@ -212,6 +212,37 @@ describe('admiralty-select', () => {
     `);
   });
 
+  it('renders a placeholder option which is disabled', async () => {
+    const id = 'custom';
+    const page = await newSpecPage({
+      components: [SelectComponent],
+      html: `<admiralty-select id="${id}"><option disabled>Select an option...</option><option>First</option></admiralty-select>`,
+    });
+
+    expect(page.root).toMatchInlineSnapshot(`
+      <admiralty-select id="${id}">
+        <!---->
+        <div class="admiralty-select">
+          <admiralty-label for="${id}-input">
+            Choose a colour
+          </admiralty-label>
+          <div class="select-wrapper">
+            <select aria-describedby=" " aria-disabled="false" aria-label="Choose a colour" class="admiralty-form-control" id="${id}-input">
+              <option disabled="">
+                Select an option...
+              </option>
+              <option>
+                First
+              </option>
+            </select>
+            <admiralty-icon class="select-down-icon" icon-name="angle-down"></admiralty-icon>
+          </div>
+          <admiralty-input-invalid id="${id}-error" style="display: none;"></admiralty-input-invalid>
+        </div>
+      </admiralty-select>
+    `);
+  });
+
   it('fires event on selection changed', async () => {
     const page = await newSpecPage({
       components: [SelectComponent],

--- a/packages/core/src/components/select/select.stories.ts
+++ b/packages/core/src/components/select/select.stories.ts
@@ -42,6 +42,22 @@ const template: Story = {
 
 export const DefaultSelect: Story = { ...template };
 
+export const PlaceholderOption: Story = {
+  render: args => html`<admiralty-select
+    value="none"
+    ?disabled="${args.disabled}"
+    ?invalid=${args.invalid}
+    invalid-message="${args.invalidMessage}"
+    hint="${args.hint}"
+    label="${args.label}"
+    width="${args.width}">
+    <option value="none" disabled>Select an option...</option>
+    <option value="first">first</option>
+    <option value="second">second</option>
+    <option value="third">third</option>
+  </admiralty-select>`,
+};
+
 export const SelectWithError: Story = {
   ...template,
   args: {


### PR DESCRIPTION
Introduced documentation on how to implement a placeholder option, with the current state.

[Select - add instruction text in input [Feature]](#145)

Here you can see the placeholder option informing the user to "select an option"
![image](https://github.com/user-attachments/assets/9db8bf98-015c-4210-b83b-bd1b2476d370)

![image](https://github.com/user-attachments/assets/f5346fad-4b61-4613-8008-d73d25be94df)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.0.0--canary.271.95bebc9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@4.0.0--canary.271.95bebc9.0
  npm install @ukho/admiralty-core@4.0.0--canary.271.95bebc9.0
  npm install @ukho/admiralty-react@4.0.0--canary.271.95bebc9.0
  # or 
  yarn add @ukho/admiralty-angular@4.0.0--canary.271.95bebc9.0
  yarn add @ukho/admiralty-core@4.0.0--canary.271.95bebc9.0
  yarn add @ukho/admiralty-react@4.0.0--canary.271.95bebc9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
