### PR TITLE
Feat: updated documentation for content design

### DIFF
--- a/packages/website/src/app/components/dialogue/dialogue.mdx
+++ b/packages/website/src/app/components/dialogue/dialogue.mdx
@@ -40,6 +40,35 @@ import Error from "@/usage/dialogue/error/index.mdx";
 
 Our dialogue components are very important as a way of communicating with a user. They are AA WCAG compliant for colour and contrast. Content in these components should be written in easy to understand and direct language.
 
+## Content Design
+
+When using the dialogue component, you must:
+make it clear why you are displaying the dialogue using plain language
+help users to understand what will happen next, including timeframes if relevant.
+Have clear and concise content and do not use:
+red text to warn people.
+
+Specifically for info dialogues, you must:
+have clear and concise content and do not use vague, unhelpful words like ‘maintenance’ or ‘improvements’
+include contact information, if it exists and helps meet a user need
+include a link to another service, if they can use it to do what they came to do.
+
+Specifically for warning dialogues, you must:
+help users to understand what will happen next based on their next action.
+
+Specifically for error dialogues, you must:
+include information about what has happened to their answers if they are in the middle of a transaction
+include contact information, if it exists and helps meet a user need
+include a link to another service, if they can use it to do what they came to do.
+
+Contact information should either be:
+a link to a specific page that includes numbers and opening times
+include all numbers and opening times.
+
+Have clear and concise content and do not use:
+jargon like 500 or bad request
+‘We are experiencing technical difficulties’.
+
 ## Props
 
 import Props from "@docs/dialogue/props.mdx";

--- a/packages/website/src/app/components/modal-dialog/modal-dialog.mdx
+++ b/packages/website/src/app/components/modal-dialog/modal-dialog.mdx
@@ -16,6 +16,18 @@ import Basic from "@/usage/modal-dialog/basic/index.mdx";
 
 Use the label and description props to provide better accessibility for the modal dialog.
 
+## Content Design
+
+When using the modal dialogue, you must:
+make it clear why you are displaying the modal dialogue using plain language
+not assume why the modal dialogue has been triggered. For example, using language like ‘Are you sure you want to leave this page?’ when the action to exit could have been accidental
+help users to understand what will happen next based on their next action.
+
+Have clear and concise content and do not use:
+jargon like 500 or bad request
+‘We are experiencing technical difficulties’
+red text to warn people.
+
 ## Props
 
 import Props from "@docs/modal-dialog/props.mdx";

--- a/packages/website/src/app/components/read-more/read-more.mdx
+++ b/packages/website/src/app/components/read-more/read-more.mdx
@@ -16,6 +16,18 @@ import Basic from "@/usage/read-more/basic/index.mdx";
 
 Ensure users with screen readers can easily navigate to the content inside the readmore expansion.
 
+# Content Design
+
+When using the read more component, you must:
+write the heading and summary line like any other button text
+use sentence case
+describe the content that will show
+keep it short (screen readers might find it difficult to navigate the component if the button text is too long).
+
+Do not use the read more component if:
+it’s content that all users need to see.
+you can simplify or reduce the amount of content.
+
 ## Props
 
 import Props from "@docs/read-more/props.mdx";

--- a/packages/website/src/app/components/read-more/read-more.mdx
+++ b/packages/website/src/app/components/read-more/read-more.mdx
@@ -16,7 +16,7 @@ import Basic from "@/usage/read-more/basic/index.mdx";
 
 Ensure users with screen readers can easily navigate to the content inside the readmore expansion.
 
-# Content Design
+## Content Design
 
 When using the read more component, you must:
 write the heading and summary line like any other button text


### PR DESCRIPTION
Updated the documentation to include a "Content Design" section for the 'Modal dialogue', 'Dialogue' and 'Read more' components

[[Feature] Content update](#220)

Modal dialogue
![Image](https://github.com/user-attachments/assets/d1bcda96-940f-4f3a-b33d-7f8da70a5c1e)
![Image](https://github.com/user-attachments/assets/49b3cd70-0c89-4c76-bd85-6860a6f1582b)

Dialogue
![Image](https://github.com/user-attachments/assets/f11675bb-dd31-4a13-aab1-5701773dd078)
![Image](https://github.com/user-attachments/assets/f7852cd2-fd46-44f6-bdbf-3c19ce3b4c73)

Read More
![Image](https://github.com/user-attachments/assets/acd55f2e-df79-4167-8e39-209a16b19db6)
![Image](https://github.com/user-attachments/assets/2e412bde-396e-4a0c-b259-6c8ed43b15c8)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.0.0--canary.272.0aa408a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@4.0.0--canary.272.0aa408a.0
  npm install @ukho/admiralty-core@4.0.0--canary.272.0aa408a.0
  npm install @ukho/admiralty-react@4.0.0--canary.272.0aa408a.0
  # or 
  yarn add @ukho/admiralty-angular@4.0.0--canary.272.0aa408a.0
  yarn add @ukho/admiralty-core@4.0.0--canary.272.0aa408a.0
  yarn add @ukho/admiralty-react@4.0.0--canary.272.0aa408a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
