### PR TITLE
Create migration guide for v2.0

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,110 @@
+# Migrating to version 2
+
+This guide provides information about how to update from v1 to v2 of the Admiralty Design System.
+
+## Styling and theme imports
+
+The themes have been separated from the styles, so the way the CSS files for the library are imported has changed. Previously they were imported as
+
+### React
+
+```tsx
+// app.tsx
+import "@ukho/admiralty-core/styles/core.css";
+```
+
+### Angular
+
+```css
+@import "@ukho/admiralty-core/styles/core.css";
+```
+
+Now they should now be imported as follows:
+
+### React
+
+```tsx
+// app.tsx
+import "@ukho/admiralty-core/styles/admiralty.bundle.css";
+import "@ukho/admiralty-core/themes/default.css";
+```
+
+### Angular
+
+```css
+/* styles.css */
+@import "@ukho/admiralty-core/styles/admiralty.bundle.css";
+@import "@ukho/admiralty-core/themes/default.css";
+```
+
+## Fonts
+
+The Johnston font is no longer included in the bundle and should be added as a dependency in your application or website:
+
+```css
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-Medium.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-Medium.woff") format("woff");
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-Bold.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-Bold.woff") format("woff");
+  font-weight: bold;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-MediumIta.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-MediumIta.woff") format("woff");
+  font-weight: 400;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-Light.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-Light.woff") format("woff");
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-LightIta.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-LightIta.woff") format("woff");
+  font-weight: 300;
+  font-style: italic;
+}
+```
+
+## CSS variables
+
+Colours in the design system can now be overridden using CSS variables. For example, to change the colour of a button, add the following CSS:
+
+```css
+button {
+  --admiralty-colour-primary: #66d762;
+  --admiralty-colour-primary-contrast: #333333;
+  --admiralty-colour-primary-shade: #41be3d;
+  --admiralty-colour-primary-tint: #8fea8b;
+}
+```
+
+Care should be taken to ensure colours are accessible and follow the [brand guidelines](https://designsystem.admiralty.co.uk/brand-guide/colour)
+
+## Breaking changes
+
+- Version 2.0 requires node.js version 16.
+- The minimum Angular version now supported is 16.2.
+- Version 2.0 requires TypeScript 4.9.3 or greater.
+
+## Deprecated features
+
+- `actionText` in the Colour Block component has been replaced with `href` and `linkText` to improve accessibility.
+

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -39,7 +39,9 @@ import "@ukho/admiralty-core/themes/default.css";
 
 ## Fonts
 
-The Johnston font is no longer included in the bundle and should be added as a dependency in your application or website:
+The Johnston font is no longer included in the bundle and should be added as a dependency in your application or website.
+
+Change the URL to match the location of where the font is being served from and then add the font definitions to your CSS file.
 
 ```css
 @font-face {

--- a/packages/website/src/app/getting-started/layout.tsx
+++ b/packages/website/src/app/getting-started/layout.tsx
@@ -9,6 +9,7 @@ const sideNavItems: SideNavItem[] = [
   { path: "angular", title: "Angular" },
   { path: "react", title: "React" },
   { path: "customising-components", title: "Customising" },
+  { path: "migrating", title: "Migrating" },
 ];
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/packages/website/src/app/getting-started/migrating/migrating.mdx
+++ b/packages/website/src/app/getting-started/migrating/migrating.mdx
@@ -1,0 +1,110 @@
+# Migrating to version 2
+
+This guide provides information about how to update from v1 to v2 of the Admiralty Design System.
+
+## Styling and theme imports
+
+The themes have been separated from the styles, so the way the CSS files for the library are imported has changed. Previously they were imported as
+
+### React
+
+```tsx
+// app.tsx
+import "@ukho/admiralty-core/styles/core.css";
+```
+
+### Angular
+
+```css
+@import "@ukho/admiralty-core/styles/core.css";
+```
+
+Now they should now be imported as follows:
+
+### React
+
+```tsx
+// app.tsx
+import "@ukho/admiralty-core/styles/admiralty.bundle.css";
+import "@ukho/admiralty-core/themes/default.css";
+```
+
+### Angular
+
+```css
+/* styles.css */
+@import "@ukho/admiralty-core/styles/admiralty.bundle.css";
+@import "@ukho/admiralty-core/themes/default.css";
+```
+
+## Fonts
+
+The Johnston font is no longer included in the bundle and should be added as a dependency in your application or website:
+
+```css
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-Medium.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-Medium.woff") format("woff");
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-Bold.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-Bold.woff") format("woff");
+  font-weight: bold;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-MediumIta.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-MediumIta.woff") format("woff");
+  font-weight: 400;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-Light.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-Light.woff") format("woff");
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "JohnstonITC";
+  src: url("webfonts/JohnstonITCStd-LightIta.woff2") format("woff2");
+  src: url("webfonts/JohnstonITCStd-LightIta.woff") format("woff");
+  font-weight: 300;
+  font-style: italic;
+}
+```
+
+## CSS variables
+
+Colours in the design system can now be overridden using CSS variables. For example, to change the colour of a button, add the following CSS:
+
+```css
+button {
+  --admiralty-colour-primary: #66d762;
+  --admiralty-colour-primary-contrast: #333333;
+  --admiralty-colour-primary-shade: #41be3d;
+  --admiralty-colour-primary-tint: #8fea8b;
+}
+```
+
+Care should be taken to ensure colours are accessible and follow the [brand guidelines](https://designsystem.admiralty.co.uk/brand-guide/colour)
+
+## Breaking changes
+
+- Version 2.0 requires node.js version 16.
+- The minimum Angular version now supported is 16.2.
+- Version 2.0 requires TypeScript 4.9.3 or greater.
+
+## Deprecated features
+
+- `actionText` in the Colour Block component has been replaced with `href` and `linkText` to improve accessibility.
+

--- a/packages/website/src/app/getting-started/migrating/migrating.mdx
+++ b/packages/website/src/app/getting-started/migrating/migrating.mdx
@@ -39,7 +39,9 @@ import "@ukho/admiralty-core/themes/default.css";
 
 ## Fonts
 
-The Johnston font is no longer included in the bundle and should be added as a dependency in your application or website:
+The Johnston font is no longer included in the bundle and should be added as a dependency in your application or website.
+
+Change the URL to match the location of where the font is being served from and then add the font definitions to your CSS file.
 
 ```css
 @font-face {

--- a/packages/website/src/app/getting-started/migrating/page.tsx
+++ b/packages/website/src/app/getting-started/migrating/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import MigratingPage from "./migrating.mdx";
+
+export default function Page() {
+  return <MigratingPage></MigratingPage>;
+}
+


### PR DESCRIPTION
Document the changes needed to use version 2.0 of the design system.

Will be available at `/getting-started/migrating` on the website.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.275.9a50db5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@2.0.0--canary.275.9a50db5.0
  npm install @ukho/admiralty-core@2.0.0--canary.275.9a50db5.0
  npm install @ukho/admiralty-react@2.0.0--canary.275.9a50db5.0
  # or 
  yarn add @ukho/admiralty-angular@2.0.0--canary.275.9a50db5.0
  yarn add @ukho/admiralty-core@2.0.0--canary.275.9a50db5.0
  yarn add @ukho/admiralty-react@2.0.0--canary.275.9a50db5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
