### PR TITLE
fix: rename id to be internalId

### DIFF
--- a/packages/core/src/components/expansion/expansion.tsx
+++ b/packages/core/src/components/expansion/expansion.tsx
@@ -35,10 +35,10 @@ export class ExpansionComponent {
    */
   @Event() toggled: EventEmitter<boolean>;
 
-  id: string = `admiralty-expansion-${++nextId}`;
+  internalId: string = `admiralty-expansion-${++nextId}`;
 
-  headerId: string = `${this.id}-header`;
-  contentId: string = `${this.id}-content`;
+  headerId: string = `${this.internalId}-header`;
+  contentId: string = `${this.internalId}-content`;
 
   onToggle() {
     this.expanded = !this.expanded;

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -7,10 +7,10 @@ import { RadioGroupChangeEventDetail } from './radio-group-interface';
   scoped: true,
 })
 export class RadioGroupComponent implements ComponentInterface {
-  private id = ++radioGroupIds;
-  private inputId: string = `admiralty-rg-${this.id}`;
-  private hintId: string = `admiralty-rg-hint-${this.id}`;
-  private errorId: string = `admiralty-rg-error-${this.id}`;
+  private internalId = ++radioGroupIds;
+  private inputId: string = `admiralty-rg-${this.internalId}`;
+  private hintId: string = `admiralty-rg-hint-${this.internalId}`;
+  private errorId: string = `admiralty-rg-error-${this.internalId}`;
 
   @Element() el!: HTMLElement;
 

--- a/packages/core/src/components/read-more/read-more.tsx
+++ b/packages/core/src/components/read-more/read-more.tsx
@@ -22,13 +22,13 @@ export class ReadMoreComponent {
    */
   @Event() admiraltyToggled: EventEmitter<boolean>;
 
-  id: string = `admiralty-read-more-${++nextId}`;
+  internalId: string = `admiralty-read-more-${++nextId}`;
 
-  headerId: string = `${this.id}-header`;
-  contentId: string = `${this.id}-content`;
+  headerId: string = `${this.internalId}-header`;
+  contentId: string = `${this.internalId}-content`;
 
   get expansionIcon(): IconDefinition {
-    return this.expanded ?  faArrowDown : faArrowRight;
+    return this.expanded ? faArrowDown : faArrowRight;
   }
 
   onToggle() {


### PR DESCRIPTION
`id` was conflicting with the native HTML `id` attribute.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.276.d611002.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@2.0.0--canary.276.d611002.0
  npm install @ukho/admiralty-core@2.0.0--canary.276.d611002.0
  npm install @ukho/admiralty-react@2.0.0--canary.276.d611002.0
  # or 
  yarn add @ukho/admiralty-angular@2.0.0--canary.276.d611002.0
  yarn add @ukho/admiralty-core@2.0.0--canary.276.d611002.0
  yarn add @ukho/admiralty-react@2.0.0--canary.276.d611002.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
