### PR TITLE
Feat: Add accessibility statement to the DS website

### DIFF
--- a/packages/website/src/app/accessbility/accessibility.mdx
+++ b/packages/website/src/app/accessbility/accessibility.mdx
@@ -1,0 +1,103 @@
+# Using the new service
+
+This statement applies to content published on the [**ukhodataupload.admiralty.co.uk**](https://ukhodataupload.admiralty.co.uk/) domain. It does not apply to content on other admiralty.co.uk subdomains.
+
+This website is run by the UK Hydrographic Office. We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
+-   zoom in up to 300% without the text spilling off the screen
+-   navigate most of the website using just a keyboard
+-   navigate most of the website using speech recognition software
+-   listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+-   see descriptive ALT attributes for images, which describe the image for non-visual readers
+-   see title attributes for links, which describe the link in greater detail.
+
+We’ve also made the website text as simple as possible to understand.
+
+AbilityNet has advice on making your device easier to use if you have a disability.
+
+<br />
+
+## How accessible is this website?
+
+We know some parts of this website are not fully accessible:
+
+-   Audio feedback to screen readers isn’t reliable.
+-   Keyboard users may find navigating the website difficult due to the missing skip link through the service.
+-   Voice activation for customised components is missing some functionalities.
+-   Colour contrast make some parts of the website difficult to understand for users with low vision.
+
+<br />
+
+## Contact information
+
+If you need information on this website in a different format, like accessible PDF, large print, easy read, audio recording or braille, contact us on:
+
+Email: [**customerservices@ukho.gov.uk**](mailto:customerservices@ukho.gov.uk)
+
+Phone: [**+44 (0)1823 484444**](tel:+441823484444)
+
+We will reply to you within 5 working days.
+
+<br />
+
+## Report accessibility problems with this website
+
+We’re always looking to improve the accessibility of this website.
+
+If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact us by emailing: [**customerservices@ukho.gov.uk**](mailto:customerservices@ukho.gov.uk) to let us know.
+
+### Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the Equality Advisory and Support Service (EASS): [**equalityadvisoryservice.com**](https://www.equalityadvisoryservice.com/).
+
+<br />
+
+## Technical information about this website’s accessibility
+
+The UK Hydrographic Office is committed to making this website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+<br />
+
+## Compliance status
+
+This website is partially compliant with the Web Content Accessibility Guidelines version 2.2 AA standard.
+
+<br />
+
+## Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+Non-compliance with the accessibility regulations:
+
+-   Some audio feedback being relayed to screen reader users does not meet the accessibility standards. For example, information was either left out, vague, or did not serve its intended purpose. This fails WCAG 2.2 success criterion 1.3.1 Info and Relationships.
+-   Some of the colours and contrasts used on the website do not meet the accessibility standards. For example, low vision issues were found when attempting to understand content on the page. This fails WCAG 2.2 success criterion 1.4.11 Non-text Contrast.
+-   Content functionality for keyboard only users does not meet the accessibility standards. For example, issues navigating the webpage due to the missing skip link through the service. This fails WCAG 2.2 success criterion 2.1.1 Keyboard.
+
+During Beta phase we will be working with our support team to update the service to solve these issues.
+
+<br />
+
+## How we tested this website
+
+Accessibility Testing Approach at UKHO documents show how we plan to improve accessibility on this website and all our products and services: [**https://github.com/UKHO/docs/blob/main/quality-assurance/web-accessibility-testing.md**](https://github.com/UKHO/docs/blob/main/quality-assurance/web-accessibility-testing.md).
+
+We use the Web Content Accessibility Guidelines V2.2 level A and level AA to test how accessible ukhodataupload.admiralty.co.uk is.
+
+In March 2024, the Digital Accessibility Centre (DAC) conducted an audit of the Data Upload service on ukhodataupload.admiralty.co.uk, from which common accessibility issues across the website were identified.
+
+<br />
+
+## What we’re doing to improve accessibility
+
+Following the audit conducted by the DAC in March 2024, we are urgently fixing content which fails to meet the Web Content Accessibility Guidelines version 2.2 AA standard.
+
+<br />
+
+## Preparation of this accessibility statement
+
+Maintaining an accessible site is an ongoing process and we are continually working to offer a user-friendly experience. However, if you have any problems using this website, contact us by emailing: [**customerservices@ukho.gov.uk**](mailto:customerservices@ukho.gov.uk).
+
+This statement was prepared on 17th May 2024. It was last reviewed on 17th May 2024. This website was last tested on 13th March 2024. The test was carried out by Digital Accessibility Centre.
+
+Accessibility testing was undertaken on the full Data Upload service.

--- a/packages/website/src/app/accessbility/accessibility.mdx
+++ b/packages/website/src/app/accessbility/accessibility.mdx
@@ -1,6 +1,6 @@
 # Using the new service
 
-This statement applies to content published on the [**ukhodataupload.admiralty.co.uk**](https://ukhodataupload.admiralty.co.uk/) domain. It does not apply to content on other admiralty.co.uk subdomains.
+This statement applies to content published on the [**designsystem.admiralty.co.uk**](https://designsystem.admiralty.co.uk/) domain. It does not apply to content on other admiralty.co.uk subdomains.
 
 This website is run by the UK Hydrographic Office. We want as many people as possible to be able to use this website. For example, that means you should be able to:
 
@@ -82,9 +82,9 @@ During Beta phase we will be working with our support team to update the service
 
 Accessibility Testing Approach at UKHO documents show how we plan to improve accessibility on this website and all our products and services: [**https://github.com/UKHO/docs/blob/main/quality-assurance/web-accessibility-testing.md**](https://github.com/UKHO/docs/blob/main/quality-assurance/web-accessibility-testing.md).
 
-We use the Web Content Accessibility Guidelines V2.2 level A and level AA to test how accessible ukhodataupload.admiralty.co.uk is.
+We use the Web Content Accessibility Guidelines V2.2 level A and level AA to test how accessible designsystem.admiralty.co.uk is.
 
-In March 2024, the Digital Accessibility Centre (DAC) conducted an audit of the Data Upload service on ukhodataupload.admiralty.co.uk, from which common accessibility issues across the website were identified.
+In March 2024, the Digital Accessibility Centre (DAC) conducted an audit of the Design System service on designsystem.admiralty.co.uk, from which common accessibility issues across the website were identified.
 
 <br />
 
@@ -100,4 +100,4 @@ Maintaining an accessible site is an ongoing process and we are continually work
 
 This statement was prepared on 17th May 2024. It was last reviewed on 17th May 2024. This website was last tested on 13th March 2024. The test was carried out by Digital Accessibility Centre.
 
-Accessibility testing was undertaken on the full Data Upload service.
+Accessibility testing was undertaken on the full Design System service.

--- a/packages/website/src/app/accessbility/layout.tsx
+++ b/packages/website/src/app/accessbility/layout.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import styles from "../accessbility/styles.module.css";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className={styles.contentContainer}>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/packages/website/src/app/accessbility/page.tsx
+++ b/packages/website/src/app/accessbility/page.tsx
@@ -1,0 +1,6 @@
+"use client"
+
+import AccessibilityPage from "./accessibility.mdx";
+export default function Home() {
+  return <AccessibilityPage></AccessibilityPage>;
+}

--- a/packages/website/src/app/accessbility/styles.module.css
+++ b/packages/website/src/app/accessbility/styles.module.css
@@ -1,0 +1,4 @@
+.contentContainer {
+  display: flex;
+  padding: 60px 11rem 0 11rem;
+}

--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -65,7 +65,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <AdmiraltyLink href="http://www.example.com" new-tab="true">
             Privacy Policy
           </AdmiraltyLink>
-          <AdmiraltyLink href="http://www.example.com">Accessibility</AdmiraltyLink>
+          <AdmiraltyLink href="/accessbility">Accessibility</AdmiraltyLink>
         </AdmiraltyFooter>
       </body>
     </html>


### PR DESCRIPTION
Implemented a accessibility page for the design system website. (Replica of Kai's accessibility page)

[[Feature] Add accessibility statement to the DS website](#186)

![image](https://github.com/user-attachments/assets/3c8a1a01-64b4-44ed-8422-77b3a6ba055a)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.1.0--canary.283.f72feac.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@3.1.0--canary.283.f72feac.0
  npm install @ukho/admiralty-core@3.1.0--canary.283.f72feac.0
  npm install @ukho/admiralty-react@3.1.0--canary.283.f72feac.0
  # or 
  yarn add @ukho/admiralty-angular@3.1.0--canary.283.f72feac.0
  yarn add @ukho/admiralty-core@3.1.0--canary.283.f72feac.0
  yarn add @ukho/admiralty-react@3.1.0--canary.283.f72feac.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
