### PR TITLE
Fix: theme file missing when packaged

### DIFF
--- a/.github/workflows/actions/build-all/action.yml
+++ b/.github/workflows/actions/build-all/action.yml
@@ -14,7 +14,7 @@ runs:
       with:
         name: admiralty-core
         output: ./packages/core/admiralty-core.zip
-        paths: ./packages/core/dist ./packages/core/loader ./packages/core/styles
+        paths: ./packages/core/dist ./packages/core/loader ./packages/core/styles ./packages/core/docs ./packages/core/themes
     - uses: ./.github/workflows/actions/upload-archive
       with:
         name: admiralty-angular


### PR DESCRIPTION
Fixes the build pipeline to include the theme file.

Fixes #306 

[Missing theme file](https://github.com/UKHO/admiralty-design-system/issues/306)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.1.1--canary.308.1f65212.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@3.1.1--canary.308.1f65212.0
  npm install @ukho/admiralty-core@3.1.1--canary.308.1f65212.0
  npm install @ukho/admiralty-react@3.1.1--canary.308.1f65212.0
  # or 
  yarn add @ukho/admiralty-angular@3.1.1--canary.308.1f65212.0
  yarn add @ukho/admiralty-core@3.1.1--canary.308.1f65212.0
  yarn add @ukho/admiralty-react@3.1.1--canary.308.1f65212.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
