### PR TITLE
Fix theme typo for font-size-7

### DIFF
--- a/packages/core/src/themes/default.css
+++ b/packages/core/src/themes/default.css
@@ -101,7 +101,7 @@
   --admiralty-font-size-4: 2rem;
   --admiralty-font-size-5: 2.25rem;
   --admiralty-font-size-6: 2.75rem;
-  --admiarlty-font-size-7: 3.5rem;
+  --admiralty-font-size-7: 3.5rem;
 
   /** Font Weight **/
   --admiralty-font-weight-normal: 300;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.0.0--canary.313.f7733aa.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@4.0.0--canary.313.f7733aa.0
  npm install @ukho/admiralty-core@4.0.0--canary.313.f7733aa.0
  npm install @ukho/admiralty-react@4.0.0--canary.313.f7733aa.0
  # or 
  yarn add @ukho/admiralty-angular@4.0.0--canary.313.f7733aa.0
  yarn add @ukho/admiralty-core@4.0.0--canary.313.f7733aa.0
  yarn add @ukho/admiralty-react@4.0.0--canary.313.f7733aa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
