### PR TITLE
332 Add link component to Documentation Website

### DIFF
--- a/packages/website/src/app/components/layout.tsx
+++ b/packages/website/src/app/components/layout.tsx
@@ -19,6 +19,7 @@ const sideNavItems: SideNavItem[] = [
   { path: "header", title: "Header" },
   { path: "horizontal-rule", title: "Horizontal Rule" },
   { path: "input", title: "Input" },
+  { path: "link", title: "Link" },
   { path: "modal-dialog", title: "Modal Dialog" },
   { path: "paginator", title: "Paginator" },
   { path: "phase-banner", title: "Phase Banner" },

--- a/packages/website/src/app/components/link/link.mdx
+++ b/packages/website/src/app/components/link/link.mdx
@@ -6,7 +6,7 @@ Use dialogue boxes to convey important information to the user.
 
 ## Basic
 
-Use this dialogue component to alert users to important information about their experience.
+Use this Link component to link users to other pages/sites.
 
 import Basic from "@/usage/link/basic/index.mdx";
 
@@ -18,32 +18,7 @@ Our dialogue components are very important as a way of communicating with a user
 
 ## Content Design
 
-When using the dialogue component, you must:
-make it clear why you are displaying the dialogue using plain language
-help users to understand what will happen next, including timeframes if relevant.
-Have clear and concise content and do not use:
-red text to warn people.
-
-Specifically for info dialogues, you must:
-have clear and concise content and do not use vague, unhelpful words like ‘maintenance’ or ‘improvements’
-include contact information, if it exists and helps meet a user need
-include a link to another service, if they can use it to do what they came to do.
-
-Specifically for warning dialogues, you must:
-help users to understand what will happen next based on their next action.
-
-Specifically for error dialogues, you must:
-include information about what has happened to their answers if they are in the middle of a transaction
-include contact information, if it exists and helps meet a user need
-include a link to another service, if they can use it to do what they came to do.
-
-Contact information should either be:
-a link to a specific page that includes numbers and opening times
-include all numbers and opening times.
-
-Have clear and concise content and do not use:
-jargon like 500 or bad request
-‘We are experiencing technical difficulties’.
+****** NEED SOME CONTENT HERE ******
 
 ## Props
 

--- a/packages/website/src/app/components/link/link.mdx
+++ b/packages/website/src/app/components/link/link.mdx
@@ -1,7 +1,3 @@
-# Link
-
-Use dialogue boxes to convey important information to the user.
-
 ## Contents
 
 ## Basic
@@ -12,9 +8,17 @@ import Basic from "@/usage/link/basic/index.mdx";
 
 <Basic />
 
+## Open in new tab
+
+Use this to link users to other pages/sites that will open in a new page.
+
+import NewTab from "@/usage/link/open-in-new-tab/index.mdx"
+
+<NewTab />
+
 ## Accessibility
 
-Our dialogue components are very important as a way of communicating with a user. They are AA WCAG compliant for colour and contrast. Content in these components should be written in easy to understand and direct language.
+****** NEED SOME CONTENT HERE ******
 
 ## Content Design
 

--- a/packages/website/src/app/components/link/link.mdx
+++ b/packages/website/src/app/components/link/link.mdx
@@ -10,7 +10,7 @@ import Basic from "@/usage/link/basic/index.mdx";
 
 ## Open in new tab
 
-Use this to link users to other pages/sites that will open in a new page.
+Use this to link users to other pages/sites that will open in a new browser tab.
 
 import NewTab from "@/usage/link/open-in-new-tab/index.mdx"
 

--- a/packages/website/src/app/components/link/link.mdx
+++ b/packages/website/src/app/components/link/link.mdx
@@ -1,0 +1,83 @@
+# Link
+
+Use dialogue boxes to convey important information to the user.
+
+## Contents
+
+## Basic
+
+Use this dialogue component to alert users to important information about their experience.
+
+import Basic from "@/usage/link/basic/index.mdx";
+
+<Basic />
+
+## Accessibility
+
+Our dialogue components are very important as a way of communicating with a user. They are AA WCAG compliant for colour and contrast. Content in these components should be written in easy to understand and direct language.
+
+## Content Design
+
+When using the dialogue component, you must:
+make it clear why you are displaying the dialogue using plain language
+help users to understand what will happen next, including timeframes if relevant.
+Have clear and concise content and do not use:
+red text to warn people.
+
+Specifically for info dialogues, you must:
+have clear and concise content and do not use vague, unhelpful words like ‘maintenance’ or ‘improvements’
+include contact information, if it exists and helps meet a user need
+include a link to another service, if they can use it to do what they came to do.
+
+Specifically for warning dialogues, you must:
+help users to understand what will happen next based on their next action.
+
+Specifically for error dialogues, you must:
+include information about what has happened to their answers if they are in the middle of a transaction
+include contact information, if it exists and helps meet a user need
+include a link to another service, if they can use it to do what they came to do.
+
+Contact information should either be:
+a link to a specific page that includes numbers and opening times
+include all numbers and opening times.
+
+Have clear and concise content and do not use:
+jargon like 500 or bad request
+‘We are experiencing technical difficulties’.
+
+## Props
+
+import Props from "@docs/link/props.mdx";
+
+<Props />
+
+## Events
+
+import Events from "@docs/link/events.mdx";
+
+<Events />
+
+## Methods
+
+import Methods from "@docs/link/methods.mdx";
+
+<Methods />
+
+## CSS Shadow Parts
+
+import Parts from "@docs/link/parts.mdx";
+
+<Parts />
+
+## CSS Custom Properties
+
+import CustomProps from "@docs/link/customProps.mdx";
+
+<CustomProps />
+
+## Slots
+
+import Slots from "@docs/link/slots.mdx";
+
+<Slots />
+

--- a/packages/website/src/app/components/link/page.tsx
+++ b/packages/website/src/app/components/link/page.tsx
@@ -1,0 +1,6 @@
+"use client";
+
+import LinksPage from "./link.mdx";
+export default function Home() {
+  return <LinksPage></LinksPage>;
+}

--- a/packages/website/src/usage/link/basic/angular.mdx
+++ b/packages/website/src/usage/link/basic/angular.mdx
@@ -1,3 +1,3 @@
 ```html
-<admiralty-input label="text" type="text"></admiralty-input>
+<admiralty-link href="https://www.example.com">Go here</admiralty-link>;
 ```

--- a/packages/website/src/usage/link/basic/angular.mdx
+++ b/packages/website/src/usage/link/basic/angular.mdx
@@ -1,3 +1,3 @@
 ```html
-<admiralty-link href="https://www.example.com">Go here</admiralty-link>;
+<admiralty-link href="https://www.example.com">Open Link</admiralty-link>;
 ```

--- a/packages/website/src/usage/link/basic/angular.mdx
+++ b/packages/website/src/usage/link/basic/angular.mdx
@@ -1,0 +1,3 @@
+```html
+<admiralty-input label="text" type="text"></admiralty-input>
+```

--- a/packages/website/src/usage/link/basic/demo.tsx
+++ b/packages/website/src/usage/link/basic/demo.tsx
@@ -2,5 +2,5 @@ import React from "react";
 import { AdmiraltyLink } from "@ukho/admiralty-react";
 
 export default function Demo() {
-  return <AdmiraltyLink href="https://www.example.com">Go here</AdmiraltyLink>;
+  return <AdmiraltyLink href="https://www.example.com">Open Link</AdmiraltyLink>;
 }

--- a/packages/website/src/usage/link/basic/demo.tsx
+++ b/packages/website/src/usage/link/basic/demo.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { AdmiraltyLink } from "@ukho/admiralty-react";
+
+export default function Demo() {
+  return <AdmiraltyLink href="www.google.com">Go here</AdmiraltyLink>;
+}

--- a/packages/website/src/usage/link/basic/demo.tsx
+++ b/packages/website/src/usage/link/basic/demo.tsx
@@ -2,5 +2,5 @@ import React from "react";
 import { AdmiraltyLink } from "@ukho/admiralty-react";
 
 export default function Demo() {
-  return <AdmiraltyLink href="www.google.com">Go here</AdmiraltyLink>;
+  return <AdmiraltyLink href="https://www.example.com">Go here</AdmiraltyLink>;
 }

--- a/packages/website/src/usage/link/basic/index.mdx
+++ b/packages/website/src/usage/link/basic/index.mdx
@@ -1,0 +1,9 @@
+import javascript from './javascript.mdx'
+import angular from './angular.mdx'
+import react from './react.mdx'
+
+import demo from './demo';
+import Playground from "@/components/playground/playground";
+
+
+<Playground code={{javascript, react,angular}} demo={demo}/>

--- a/packages/website/src/usage/link/basic/javascript.mdx
+++ b/packages/website/src/usage/link/basic/javascript.mdx
@@ -1,3 +1,3 @@
 ```html
-<admiralty-input label="text" type="text"></admiralty-input>
+<admiralty-link href="https://www.example.com">Go here</admiralty-link>;
 ```

--- a/packages/website/src/usage/link/basic/javascript.mdx
+++ b/packages/website/src/usage/link/basic/javascript.mdx
@@ -1,3 +1,3 @@
 ```html
-<admiralty-link href="https://www.example.com">Go here</admiralty-link>;
+<admiralty-link href="https://www.example.com">Open Link</admiralty-link>;
 ```

--- a/packages/website/src/usage/link/basic/javascript.mdx
+++ b/packages/website/src/usage/link/basic/javascript.mdx
@@ -1,0 +1,3 @@
+```html
+<admiralty-input label="text" type="text"></admiralty-input>
+```

--- a/packages/website/src/usage/link/basic/react.mdx
+++ b/packages/website/src/usage/link/basic/react.mdx
@@ -1,3 +1,3 @@
 ```tsx
-<AdmiraltyInput label="text" type="text"></AdmiraltyInput>
+<AdmiraltyLink href="https://www.example.com">Go here</AdmiraltyLink>
 ```

--- a/packages/website/src/usage/link/basic/react.mdx
+++ b/packages/website/src/usage/link/basic/react.mdx
@@ -1,3 +1,3 @@
 ```tsx
-<AdmiraltyLink href="https://www.example.com">Go here</AdmiraltyLink>
+<AdmiraltyLink href="https://www.example.com">Open Link</AdmiraltyLink>
 ```

--- a/packages/website/src/usage/link/basic/react.mdx
+++ b/packages/website/src/usage/link/basic/react.mdx
@@ -1,0 +1,3 @@
+```tsx
+<AdmiraltyInput label="text" type="text"></AdmiraltyInput>
+```

--- a/packages/website/src/usage/link/open-in-new-tab/angular.mdx
+++ b/packages/website/src/usage/link/open-in-new-tab/angular.mdx
@@ -1,0 +1,3 @@
+```html
+<admiralty-link href="https://www.example.com" new-tab="true">Open link in new tab</admiralty-link>
+```

--- a/packages/website/src/usage/link/open-in-new-tab/demo.tsx
+++ b/packages/website/src/usage/link/open-in-new-tab/demo.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { AdmiraltyLink } from "@ukho/admiralty-react";
+
+export default function Demo() {
+  return <AdmiraltyLink href="https://www.example.com" newTab={true}>Open link in new tab</AdmiraltyLink>;
+}

--- a/packages/website/src/usage/link/open-in-new-tab/index.mdx
+++ b/packages/website/src/usage/link/open-in-new-tab/index.mdx
@@ -1,0 +1,9 @@
+import javascript from './javascript.mdx'
+import angular from './angular.mdx'
+import react from './react.mdx'
+
+import demo from './demo';
+import Playground from "@/components/playground/playground";
+
+
+<Playground code={{javascript, react,angular}} demo={demo}/>

--- a/packages/website/src/usage/link/open-in-new-tab/javascript.mdx
+++ b/packages/website/src/usage/link/open-in-new-tab/javascript.mdx
@@ -1,0 +1,3 @@
+```html
+<admiralty-link href="https://www.example.com" new-tab="true">Open link in new tab</admiralty-link>
+```

--- a/packages/website/src/usage/link/open-in-new-tab/react.mdx
+++ b/packages/website/src/usage/link/open-in-new-tab/react.mdx
@@ -1,0 +1,3 @@
+```tsx
+<AdmiraltyLink href="https://www.example.com" newTab={true}>Open link in new tab</AdmiraltyLink>
+```


### PR DESCRIPTION
#332 

Add link component example to documentation website.

Includes **basic link** and **open link in new tab** variants.