### PR TITLE
Fix: Remove Alpha Phase Banner

### DIFF
--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -59,11 +59,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </AdmiraltyHeaderMenuLink>
           ))}
         </AdmiraltyHeader>
-        <div>
-          <AdmiraltyPhaseBanner
-            phase="alpha"
-            link="https://github.com/UKHO/admiralty-design-system/issues/new/choose"></AdmiraltyPhaseBanner>
-        </div>
         <main id="main-content">{children}</main>
         <AdmiraltyFooter imageSrc="/svg/UKHO stacked logo.svg">
           <AdmiraltyLink href="http://www.example.com" new-tab="true">


### PR DESCRIPTION
As the Documentation website is no longer in Alpha, we are removing the phase banner to reflect this.