### PR TITLE
Add initial dark-mode

### DIFF
--- a/packages/core/src/themes/default.css
+++ b/packages/core/src/themes/default.css
@@ -108,3 +108,17 @@
   --admiralty-font-weight-medium: 400;
   --admiralty-font-weight-bold: 700;
 }
+
+ /** Dark Mode **/
+
+@media (prefers-color-scheme: dark) {
+  .theme {
+    /** Dark **/
+    --admiralty-colour-secondary: #405357;
+    --admiralty-colour-tertiary: #92A9AE;
+    --admiralty-focus-colour: #FBE86C;
+    --admiralty-colour-info: #60A4CE;
+    --admiralty-colour-success: #87BA7C;
+    --admiralty-colour-danger: #D86666;
+  }
+}

--- a/packages/core/src/themes/default.css
+++ b/packages/core/src/themes/default.css
@@ -110,7 +110,6 @@
 }
 
  /** Dark Mode **/
-
 @media (prefers-color-scheme: dark) {
   .theme {
     /** Dark **/


### PR DESCRIPTION
Add prefers-colour-scheme: dark class in default.css to add some initial darkmode colours.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.2--canary.343.278cb1a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@4.1.2--canary.343.278cb1a.0
  npm install @ukho/admiralty-core@4.1.2--canary.343.278cb1a.0
  npm install @ukho/admiralty-react@4.1.2--canary.343.278cb1a.0
  # or 
  yarn add @ukho/admiralty-angular@4.1.2--canary.343.278cb1a.0
  yarn add @ukho/admiralty-core@4.1.2--canary.343.278cb1a.0
  yarn add @ukho/admiralty-react@4.1.2--canary.343.278cb1a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
