### PR TITLE
Update actions/cache from 4.0.2 -> 4.2.0

### DIFF
--- a/.github/workflows/actions/yarn-cache/action.yml
+++ b/.github/workflows/actions/yarn-cache/action.yml
@@ -7,7 +7,7 @@ runs:
       id: yarn-cache-dir-path
       shell: bash
       run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@v4.2.0
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
Updating actions/cache as previous version was deprecated and causing build issues
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.2--canary.347.4f57487.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@4.1.2--canary.347.4f57487.0
  npm install @ukho/admiralty-core@4.1.2--canary.347.4f57487.0
  npm install @ukho/admiralty-react@4.1.2--canary.347.4f57487.0
  # or 
  yarn add @ukho/admiralty-angular@4.1.2--canary.347.4f57487.0
  yarn add @ukho/admiralty-core@4.1.2--canary.347.4f57487.0
  yarn add @ukho/admiralty-react@4.1.2--canary.347.4f57487.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
