### PR TITLE
Fixing the broken option export causing Angular builds to fail when using autocomplete component

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { AutoCompleteChangeEventDetail } from "./components/autocomplete/autocomplete.interface";
+import { AutoCompleteChangeEventDetail, Option } from "./components/autocomplete/autocomplete.interface";
 import { ButtonVariant } from "./components/button/button.types";
 import { IconName, IconPrefix } from "@fortawesome/fontawesome-svg-core";
 import { CheckboxChangeEventDetail } from "./components/checkbox/checkbox.interface";
@@ -16,7 +16,7 @@ import { InputChangeEventDetail } from "./components/input/input.interface";
 import { RadioGroupChangeEventDetail } from "./components/radio-group/radio-group-interface";
 import { SelectChangeEventDetail } from "./components/select/select.interface";
 import { TextAreaChangeEventDetail } from "./components/textarea/textarea.interface";
-export { AutoCompleteChangeEventDetail } from "./components/autocomplete/autocomplete.interface";
+export { AutoCompleteChangeEventDetail, Option } from "./components/autocomplete/autocomplete.interface";
 export { ButtonVariant } from "./components/button/button.types";
 export { IconName, IconPrefix } from "@fortawesome/fontawesome-svg-core";
 export { CheckboxChangeEventDetail } from "./components/checkbox/checkbox.interface";

--- a/packages/core/src/components/autocomplete/autocomplete.interface.ts
+++ b/packages/core/src/components/autocomplete/autocomplete.interface.ts
@@ -1,3 +1,8 @@
 export interface AutoCompleteChangeEventDetail {
   value: any;
 }
+
+export interface Option {
+  text: string;
+  value: any;
+}

--- a/packages/core/src/components/autocomplete/autocomplete.tsx
+++ b/packages/core/src/components/autocomplete/autocomplete.tsx
@@ -4,12 +4,7 @@
 
 import { Component, forceUpdate, Prop, State, h, Element, EventEmitter, Event, Watch } from '@stencil/core';
 import { watchForOptions } from './optionsWatcher';
-import { AutoCompleteChangeEventDetail } from './autocomplete.interface';
-
-interface Option {
-  text: string;
-  value: any;
-}
+import { AutoCompleteChangeEventDetail, Option } from './autocomplete.interface';
 
 const keyCodes = {
   13: 'enter',


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.2.1--canary.366.e22dc68.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@4.2.1--canary.366.e22dc68.0
  npm install @ukho/admiralty-core@4.2.1--canary.366.e22dc68.0
  npm install @ukho/admiralty-react@4.2.1--canary.366.e22dc68.0
  # or 
  yarn add @ukho/admiralty-angular@4.2.1--canary.366.e22dc68.0
  yarn add @ukho/admiralty-core@4.2.1--canary.366.e22dc68.0
  yarn add @ukho/admiralty-react@4.2.1--canary.366.e22dc68.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
