### PR TITLE
Fix: side nav item not focusing when tabbing

### DIFF
--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -168,6 +168,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                         onTextSideBarItemClick={() => router.push(path)}
                         suppress-redirect="true"
                         variant={variant as TextSideBarItemVariant}
+                        href={path}
                         itemText={name}></AdmiraltyTextSideBarItem>
                     ))}
                   </AdmiraltyTextSideBarItem>


### PR DESCRIPTION
Fixed this by adding the HREF to the anchor to make it focusable 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.0.2--canary.395.cc2f4c7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@5.0.2--canary.395.cc2f4c7.0
  npm install @ukho/admiralty-core@5.0.2--canary.395.cc2f4c7.0
  npm install @ukho/admiralty-react@5.0.2--canary.395.cc2f4c7.0
  # or 
  yarn add @ukho/admiralty-angular@5.0.2--canary.395.cc2f4c7.0
  yarn add @ukho/admiralty-core@5.0.2--canary.395.cc2f4c7.0
  yarn add @ukho/admiralty-react@5.0.2--canary.395.cc2f4c7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
