### PR TITLE
Feat: release email logic

### DIFF
--- a/.github/workflows/release-email.yml
+++ b/.github/workflows/release-email.yml
@@ -1,0 +1,33 @@
+name: Send Release Email
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  send-email:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install SendGrid
+        run: npm install @sendgrid/mail
+
+      - name: Send release email
+        if: env.SEND_RELEASE_EMAIL == 'true'
+        run: |
+          node scripts/send-release-email.js \
+            "${{ github.event.release.tag_name }}" \
+            "${{ github.event.release.body }}"
+        env:
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          FROM_EMAIL: ${{ vars.FROM_EMAIL}}
+          RECIPIENTS: ${{ vars.RECIPIENTS }}
+          SEND_RELEASE_EMAIL: ${{ vars.SEND_RELEASE_EMAIL }}
+          SG_TEMPLATE_ID: ${{ vars.SG_TEMPLATE_ID }}

--- a/scripts/send-release-email.js
+++ b/scripts/send-release-email.js
@@ -10,7 +10,7 @@ if (!templateId || !fromEmail) {
 }
 
 if (recipients.length === 0) {
-  console.error(`❌ No recipients set. Please defined RECIPIENTS repository environment variable`)
+  console.error(`❌ No recipients set. Please define RECIPIENTS repository environment variable`)
 }
 
 const msg = {

--- a/scripts/send-release-email.js
+++ b/scripts/send-release-email.js
@@ -1,0 +1,27 @@
+const sendGridMail = require('@sendgrid/mail');
+sendGridMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+const recipients = process.env.RECIPIENTS ? process.env.RECIPIENTS.split(",").map(r => r.trim()) : [];
+const templateId = process.env.SG_TEMPLATE_ID;
+const fromEmail = process.env.FROM_EMAIL;
+
+if (!templateId || !fromEmail) {
+  console.error(`❌ Missing SG_TEMPLATE_ID or FROM_EMAIL repository environment variable`)
+}
+
+if (recipients.length === 0) {
+  console.error(`❌ No recipients set. Please defined RECIPIENTS repository environment variable`)
+}
+
+const msg = {
+  to: recipients,
+  from: process.env.FROM_EMAIL,
+  templateId: process.env.SG_TEMPLATE_ID
+}
+
+sendGridMail.sendMultiple(msg)
+  .then(() => console.log(`✔️ Release email successfully sent!`))
+  .catch(err => {
+    console.error(`❌ Release email failed to send!`);
+    process.exit(1);
+  });


### PR DESCRIPTION
Automatically sends an email out when a new package version has been published and also dependant on repository environment variable being true
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.0.2--canary.402.be67e5d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@5.0.2--canary.402.be67e5d.0
  npm install @ukho/admiralty-core@5.0.2--canary.402.be67e5d.0
  npm install @ukho/admiralty-react@5.0.2--canary.402.be67e5d.0
  # or 
  yarn add @ukho/admiralty-angular@5.0.2--canary.402.be67e5d.0
  yarn add @ukho/admiralty-core@5.0.2--canary.402.be67e5d.0
  yarn add @ukho/admiralty-react@5.0.2--canary.402.be67e5d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
