### PR TITLE
fix: DataTransfer null check in FileInput component

### DIFF
--- a/packages/core/src/components/file-input/file-input.tsx
+++ b/packages/core/src/components/file-input/file-input.tsx
@@ -89,6 +89,11 @@ export class FileInputComponent {
     event.preventDefault();
     this.el.querySelector('.admiralty-file-input').classList.remove('drop_zone');
 
+    // Guard against null dataTransfer (permitted by the DragEvent spec)
+    if (!event.dataTransfer) {
+      return;
+    }
+
     if (event.dataTransfer.files) {
       this.storeFileInfo(event.dataTransfer.files);
       this.fileInputChange.emit({ files: this.files });

--- a/packages/core/src/components/footer/footer.scss
+++ b/packages/core/src/components/footer/footer.scss
@@ -11,7 +11,7 @@ footer {
   border-top: $footer-border-colour 0.375rem solid;
   background: $footer-background-colour;
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
 
   .footer-branding {
     .footer-img {
@@ -54,7 +54,6 @@ footer {
   .footer-content {
     @include tablet-or-desktop {
       display: flex;
-      flex-grow: 1;
       flex-direction: column;
     }
     .footer-links {
@@ -65,11 +64,8 @@ footer {
         gap: 1.5rem;
       }
       display: flex;
-      flex-direction: column;
-      align-self: flex-start;
       margin-left: $footer-content-links-margin-left;
-      gap: 0.5rem;
-      flex-grow: 1;
+      gap: 1.5rem;
 
       ::slotted(admiralty-link) {
         a {

--- a/packages/core/src/components/footer/footer.scss
+++ b/packages/core/src/components/footer/footer.scss
@@ -64,6 +64,7 @@ footer {
         gap: 1.5rem;
       }
       display: flex;
+      flex-grow: 1;
       margin-left: $footer-content-links-margin-left;
       gap: 1.5rem;
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.5.3--canary.482.41747f8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@5.5.3--canary.482.41747f8.0
  npm install @ukho/admiralty-core@5.5.3--canary.482.41747f8.0
  npm install @ukho-internal/admiralty-docs@5.5.3--canary.482.41747f8.0
  npm install @ukho/admiralty-react@5.5.3--canary.482.41747f8.0
  npm install test-app@5.5.3--canary.482.41747f8.0
  npm install website@5.5.3--canary.482.41747f8.0
  # or 
  yarn add @ukho/admiralty-angular@5.5.3--canary.482.41747f8.0
  yarn add @ukho/admiralty-core@5.5.3--canary.482.41747f8.0
  yarn add @ukho-internal/admiralty-docs@5.5.3--canary.482.41747f8.0
  yarn add @ukho/admiralty-react@5.5.3--canary.482.41747f8.0
  yarn add test-app@5.5.3--canary.482.41747f8.0
  yarn add website@5.5.3--canary.482.41747f8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
