### PR TITLE
Accessibility fixes

### DIFF
--- a/packages/core/src/components/radio-group/radio-group.spec.ts
+++ b/packages/core/src/components/radio-group/radio-group.spec.ts
@@ -10,7 +10,7 @@ describe('radio-group', () => {
     });
     expect(page.root).toEqualHtml(`
       <admiralty-radio-group>
-        <fieldset aria-describedby=" " aria-invalid="false" role="radiogroup">
+        <fieldset aria-describedby=" " aria-invalid="false">
           <div class="radio-group stack"></div>
           <admiralty-input-invalid id="admiralty-rg-error-1" style="display: none;"></admiralty-input-invalid>
         </fieldset>
@@ -32,7 +32,7 @@ describe('radio-group', () => {
     expect(page.root).toMatchInlineSnapshot(`
       <admiralty-radio-group display-vertical="false">
         <!---->
-        <fieldset aria-describedby=" " aria-invalid="false" role="radiogroup">
+        <fieldset aria-describedby=" " aria-invalid="false">
           <div class="radio-group">
             <admiralty-radio name="grp" value="option1">
               <!---->
@@ -75,7 +75,7 @@ describe('radio-group', () => {
     expect(page.root).toMatchInlineSnapshot(`
       <admiralty-radio-group display-vertical="true">
         <!---->
-        <fieldset aria-describedby=" " aria-invalid="false" role="radiogroup">
+        <fieldset aria-describedby=" " aria-invalid="false">
           <div class="radio-group stack">
             <admiralty-radio name="grp" value="option1">
               <!---->
@@ -145,7 +145,7 @@ describe('radio-group', () => {
     expect(page.root).toMatchInlineSnapshot(`
       <admiralty-radio-group disabled="true">
         <!---->
-        <fieldset aria-describedby=" " aria-invalid="false" disabled="" role="radiogroup">
+        <fieldset aria-describedby=" " aria-invalid="false" disabled="">
           <div class="radio-group stack">
             <admiralty-radio name="grp" value="option1">
               <!---->
@@ -188,7 +188,7 @@ describe('radio-group', () => {
     expect(page.root).toMatchInlineSnapshot(`
       <admiralty-radio-group hint="Hint text" label="Label text">
         <!---->
-        <fieldset aria-describedby="admiralty-rg-hint-6 " aria-invalid="false" role="radiogroup">
+        <fieldset aria-describedby="admiralty-rg-hint-6 " aria-invalid="false">
           <legend>
             Label text
           </legend>

--- a/packages/core/src/components/radio-group/radio-group.tsx
+++ b/packages/core/src/components/radio-group/radio-group.tsx
@@ -126,7 +126,6 @@ export class RadioGroupComponent implements ComponentInterface {
       <Host>
         <fieldset
           disabled={this.disabled}
-          role="radiogroup"
           aria-invalid={this.invalid ? 'true' : 'false'}
           aria-describedby={(this.hint ? this.hintId : '') + ' ' + (this.invalid ? this.errorId : '')}
         >

--- a/packages/core/src/components/theme-toggle/theme-toggle.spec.ts
+++ b/packages/core/src/components/theme-toggle/theme-toggle.spec.ts
@@ -3,26 +3,6 @@ import { ThemeToggleComponent } from './theme-toggle';
 
 describe('admiralty-theme-toggle', () => {
   describe('rendering', () => {
-    it('should render the theme toggle button', async () => {
-      const page = await newSpecPage({
-        components: [ThemeToggleComponent],
-        html: `<admiralty-theme-toggle></admiralty-theme-toggle>`,
-      });
-      expect(page.root).toEqualHtml(`
-        <admiralty-theme-toggle theme="auto">
-          <button aria-label="Toggle dark mode" class="theme-toggle light" type="button">
-            <span class="toggle-background-slider"></span>
-            <span class="toggle-icon sun-icon">
-              <admiralty-icon name="light-mode-outline"></admiralty-icon>
-            </span>
-            <span class="toggle-icon moon-icon">
-              <admiralty-icon name="dark-mode-outline"></admiralty-icon>
-            </span>
-          </button>
-        </admiralty-theme-toggle>
-      `);
-    });
-
     it('should have button type="button"', async () => {
       const page = await newSpecPage({
         components: [ThemeToggleComponent],
@@ -54,22 +34,28 @@ describe('admiralty-theme-toggle', () => {
       expect(moonIcon.getAttribute('name')).toBe('dark-mode-outline');
     });
 
-    it('should render with custom aria-label', async () => {
-      const page = await newSpecPage({
-        components: [ThemeToggleComponent],
-        html: `<admiralty-theme-toggle aria-label="Custom label"></admiralty-theme-toggle>`,
-      });
-      const button = page.root.querySelector('button');
-      expect(button.getAttribute('aria-label')).toBe('Custom label');
-    });
-
-    it('should use default aria-label', async () => {
+    it('should use computed default aria-label', async () => {
       const page = await newSpecPage({
         components: [ThemeToggleComponent],
         html: `<admiralty-theme-toggle></admiralty-theme-toggle>`,
       });
+
       const button = page.root.querySelector('button');
-      expect(button.getAttribute('aria-label')).toBe('Toggle dark mode');
+
+      expect(button.getAttribute('aria-label')).toMatch(
+        /Toggle dark mode \(current: .*\. Press to switch to .* mode\)/
+      );
+    });
+
+    it('should use custom aria-label when provided', async () => {
+      const page = await newSpecPage({
+        components: [ThemeToggleComponent],
+        html: `<admiralty-theme-toggle aria-label="Custom theme toggle"></admiralty-theme-toggle>`,
+      });
+
+      const button = page.root.querySelector('button');
+
+      expect(button.getAttribute('aria-label')).toBe('Custom theme toggle');
     });
   });
 

--- a/packages/core/src/components/theme-toggle/theme-toggle.spec.ts
+++ b/packages/core/src/components/theme-toggle/theme-toggle.spec.ts
@@ -3,6 +3,25 @@ import { ThemeToggleComponent } from './theme-toggle';
 
 describe('admiralty-theme-toggle', () => {
   describe('rendering', () => {
+
+    it('should render the theme toggle button', async () => {
+      const page = await newSpecPage({
+        components: [ThemeToggleComponent],
+        html: `<admiralty-theme-toggle></admiralty-theme-toggle>`,
+      });
+
+      const button = page.root.querySelector('button');
+
+      expect(button).toHaveClass('theme-toggle');
+      expect(button).toHaveClass('light');
+      expect(button.getAttribute('type')).toBe('button');
+
+      expect(button.getAttribute('aria-label')).toBe(
+        'Toggle dark mode (current: auto (light system preference). Press to switch to dark mode)'
+      );
+    });
+
+
     it('should have button type="button"', async () => {
       const page = await newSpecPage({
         components: [ThemeToggleComponent],

--- a/packages/core/src/components/theme-toggle/theme-toggle.tsx
+++ b/packages/core/src/components/theme-toggle/theme-toggle.tsx
@@ -222,6 +222,13 @@ export class ThemeToggleComponent {
 
   render() {
     const isDark = this.isDarkMode();
+    const currentThemeLabel = this.theme === 'auto'
+    ? `auto (${isDark ? 'dark' : 'light'} system preference)`
+      : this.theme;
+
+    const computedAriaLabel = this.ariaLabel !== 'Toggle dark mode'
+      ? this.ariaLabel
+      : `Toggle dark mode (current: ${currentThemeLabel}. Press to switch to ${isDark ? 'light' : 'dark'} mode)`;
 
     return (
       <Host>
@@ -234,7 +241,8 @@ export class ThemeToggleComponent {
           }}
           onClick={this.toggleTheme}
           disabled={this.disabled}
-          aria-label={this.ariaLabel}
+          aria-label={computedAriaLabel}
+          aria-pressed={isDark}
           type="button"
         >
           <span class="toggle-background-slider"></span>


### PR DESCRIPTION
Update Theme Toggle component to announce current theme when focused.
Update Radio Group component to remove role="radiogroup".

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.1--canary.497.4b4776d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@5.6.1--canary.497.4b4776d.0
  npm install @ukho/admiralty-core@5.6.1--canary.497.4b4776d.0
  npm install @ukho-internal/admiralty-docs@5.6.1--canary.497.4b4776d.0
  npm install @ukho/admiralty-react@5.6.1--canary.497.4b4776d.0
  npm install test-app@5.6.1--canary.497.4b4776d.0
  npm install website@5.6.1--canary.497.4b4776d.0
  # or 
  yarn add @ukho/admiralty-angular@5.6.1--canary.497.4b4776d.0
  yarn add @ukho/admiralty-core@5.6.1--canary.497.4b4776d.0
  yarn add @ukho-internal/admiralty-docs@5.6.1--canary.497.4b4776d.0
  yarn add @ukho/admiralty-react@5.6.1--canary.497.4b4776d.0
  yarn add test-app@5.6.1--canary.497.4b4776d.0
  yarn add website@5.6.1--canary.497.4b4776d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
