### PR TITLE
Dynamic Progress Tracker Headings 

### DIFF
--- a/packages/core/src/components/progress-tracker-step/progress-tracker-step.tsx
+++ b/packages/core/src/components/progress-tracker-step/progress-tracker-step.tsx
@@ -16,22 +16,22 @@ export class ProgressTrackerStepComponent {
   /**
    * Unique identifier for the step
    */
-  @Prop() stepId!: string;
+  @Prop({ reflect: true }) stepId!: string;
 
   /**
    * The title text displayed for the step
    */
-  @Prop() stepTitle!: string;
+  @Prop({ reflect: true }) stepTitle!: string;
 
   /**
    * The current status of the step
    */
-  @Prop() status: StepStatus = 'upcoming';
+  @Prop({ reflect: true }) status: StepStatus = 'upcoming';
 
   /**
    * Optional summary text displayed below the title
    */
-  @Prop() summary?: string;
+  @Prop({ reflect: true }) summary?: string;
 
   render() {
     // This component is just a data container, the parent renders it

--- a/packages/core/src/components/progress-tracker/progress-tracker.tsx
+++ b/packages/core/src/components/progress-tracker/progress-tracker.tsx
@@ -21,9 +21,9 @@ export class ProgressTrackerComponent {
   @Prop() allowBackNavigation = true;
 
   /**
-   * Whether navigation to future steps is allowed. Set to false by default to prevent users from skipping ahead in a process.
+   * Whether navigation to future steps is allowed
    */
-  @Prop() allowForwardNavigation = false;
+  @Prop() allowForwardNavigation = true;
 
   /**
    * Emitted when user clicks on a step
@@ -113,10 +113,10 @@ export class ProgressTrackerComponent {
       }
 
       return {
-        id: stepEl.getAttribute('step-id') || stepEl.stepId || '',
-        title: stepEl.getAttribute('step-title') || stepEl.stepTitle || '',
-        status: (stepEl.getAttribute('status') || stepEl.status || 'upcoming') as StepStatus,
-        summary: stepEl.getAttribute('summary') || stepEl.summary,
+        id: stepEl.stepId || stepEl.getAttribute('step-id') || '',
+        title: stepEl.stepTitle || stepEl.getAttribute('step-title') || '',
+        status: (stepEl.status || stepEl.getAttribute('status') || 'upcoming') as StepStatus,
+        summary: stepEl.summary || stepEl.getAttribute('summary'),
         bulletSummaries: bulletSummaries.length > 0 ? bulletSummaries : undefined,
       };
     });

--- a/packages/core/src/components/progress-tracker/progress-tracker.tsx
+++ b/packages/core/src/components/progress-tracker/progress-tracker.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, Event, EventEmitter, State, Host, Element } from '@stencil/core';
 
-export type StepStatus = 'complete' | 'current' | 'upcoming';
+export type StepStatus = 'complete' | 'current' | 'upcoming' | 'error';
 
 export interface StepNavigationDetail {
   stepId: string;
@@ -21,9 +21,9 @@ export class ProgressTrackerComponent {
   @Prop() allowBackNavigation = true;
 
   /**
-   * Whether navigation to future steps is allowed
+   * Whether navigation to future steps is allowed. Set to false by default to prevent users from skipping ahead in a process.
    */
-  @Prop() allowForwardNavigation = true;
+  @Prop() allowForwardNavigation = false;
 
   /**
    * Emitted when user clicks on a step
@@ -39,7 +39,12 @@ export class ProgressTrackerComponent {
     bulletSummaries?: string[];
   }> = [];
 
+  @State() liveMessage = '';
+
   private observer?: MutationObserver;
+  private previousCurrentStepId: string | null = null;
+  private lastActiveStepIndex: number | null = null;
+  private hasInitialised = false;
 
   componentWillLoad() {
     this.updateStepsFromChildren();
@@ -115,6 +120,25 @@ export class ProgressTrackerComponent {
         bulletSummaries: bulletSummaries.length > 0 ? bulletSummaries : undefined,
       };
     });
+
+    this.announceCurrentStepChange();
+  }
+
+  private announceCurrentStepChange() {
+    const steps = this.getSteps();
+    const currentIndex = steps.findIndex(step => step.status === 'current');
+    const current = currentIndex === -1 ? undefined : steps[currentIndex];
+
+    if (!this.hasInitialised) {
+      this.hasInitialised = true;
+      this.previousCurrentStepId = current?.id ?? null;
+      return;
+    }
+
+    if (current && current.id !== this.previousCurrentStepId) {
+      this.liveMessage = `Now on step ${currentIndex + 1} of ${steps.length}: ${current.title}`;
+      this.previousCurrentStepId = current.id;
+    }
   }
 
   private getSteps() {
@@ -140,6 +164,10 @@ export class ProgressTrackerComponent {
 
     if (status === 'current') {
       return <span class="progress-tracker-marker progress-tracker-marker--current" aria-label="Current step"></span>;
+    }
+
+    if (status === 'error') {
+      return <span class="progress-tracker-marker progress-tracker-marker--error" aria-label="Step has an error"></span>;
     }
 
     return <span class="progress-tracker-marker progress-tracker-marker--upcoming" aria-label="Upcoming step"></span>;
@@ -216,6 +244,47 @@ export class ProgressTrackerComponent {
     }
   }
 
+  componentWillRender() {
+    const active = document.activeElement as HTMLElement | null;
+    if (active && this.el.contains(active) && active.hasAttribute('data-step-index')) {
+      const index = parseInt(active.getAttribute('data-step-index') || '', 10);
+      this.lastActiveStepIndex = Number.isNaN(index) ? null : index;
+    } else {
+      this.lastActiveStepIndex = null;
+    }
+  }
+
+  componentDidRender() {
+    if (this.lastActiveStepIndex === null) return;
+
+    const stillPresent = this.el.querySelector(`button[data-step-index="${this.lastActiveStepIndex}"]`);
+    if (!stillPresent) {
+      const steps = this.getSteps();
+      let target: number | null = null;
+
+      for (let i = this.lastActiveStepIndex; i < steps.length; i++) {
+        if (this.isStepClickable(i)) {
+          target = i;
+          break;
+        }
+      }
+      if (target === null) {
+        for (let i = this.lastActiveStepIndex - 1; i >= 0; i--) {
+          if (this.isStepClickable(i)) {
+            target = i;
+            break;
+          }
+        }
+      }
+
+      if (target !== null) {
+        this.focusButton(target);
+      }
+    }
+
+    this.lastActiveStepIndex = null;
+  }
+
   render() {
     const steps = this.getSteps();
 
@@ -278,6 +347,10 @@ export class ProgressTrackerComponent {
             })}
           </ol>
         </nav>
+        <div class="progress-tracker-visually-hidden" aria-live="polite" aria-atomic="true">
+          {this.liveMessage}
+        </div>
+
         {/* Hidden slot for child step components */}
         <div style={{ display: 'none' }}>
           <slot></slot>

--- a/packages/website/src/app/updates/v5-6/v5-6.mdx
+++ b/packages/website/src/app/updates/v5-6/v5-6.mdx
@@ -2,7 +2,7 @@ import styles from "./styles.css"
 
 # Version 5.6 Release Notes
 
-### Release date 13/02/2026
+### Release date 23/06/2026
 
 ## Summary
 

--- a/packages/website/src/components/colour-blocks/colour-blocks.tsx
+++ b/packages/website/src/components/colour-blocks/colour-blocks.tsx
@@ -8,11 +8,10 @@ export default function ColourBlocks() {
     <div className={styles.homePageContainer}>
       <div className={styles.latestUpdates}>
         <h2>Updates</h2>
-        <h3>Last Updated February 2026</h3>
-        <p>We released ADMIRALTY Design System version 5.3.0. This update introduces Dark Mode,
-          improving usability in low-light environments and supporting user preference-based theming. It also launches a
-          new Patterns section to help teams design more consistent and scalable services by providing guidance on
-          common service structures, interaction behaviour, and layout approaches.</p></div>
+        <h3>Last Updated June 2026</h3>
+        <p>We released ADMIRALTY Design System version 5.6.0. This update introduces a dedicated Dark Mode toggle, giving users explicit control over theme selection,
+          alongside new Tooltip and Progress Tracker components to support more intuitive and accessible user experiences.
+          It also enhances the Autocomplete component with configurable icons, providing greater flexibility.</p></div>
       <div className={styles.colourBlocksContainer}>
         <AdmiraltyColourBlock
           width={434}


### PR DESCRIPTION
Dynamically update Progress Tracker step headings to buttons when they are clickable to make it more accessible for screen readers.

set allowForwardNavigation to false by default.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.8.0--canary.510.e050cae.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@5.8.0--canary.510.e050cae.0
  npm install @ukho/admiralty-core@5.8.0--canary.510.e050cae.0
  npm install @ukho-internal/admiralty-docs@5.8.0--canary.510.e050cae.0
  npm install @ukho/admiralty-react@5.8.0--canary.510.e050cae.0
  npm install test-app@5.8.0--canary.510.e050cae.0
  npm install website@5.8.0--canary.510.e050cae.0
  # or 
  yarn add @ukho/admiralty-angular@5.8.0--canary.510.e050cae.0
  yarn add @ukho/admiralty-core@5.8.0--canary.510.e050cae.0
  yarn add @ukho-internal/admiralty-docs@5.8.0--canary.510.e050cae.0
  yarn add @ukho/admiralty-react@5.8.0--canary.510.e050cae.0
  yarn add test-app@5.8.0--canary.510.e050cae.0
  yarn add website@5.8.0--canary.510.e050cae.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
