### PR TITLE
218859 [BUG] Bullet point text wrapping

### DIFF
--- a/packages/website/src/app/styles.module.css
+++ b/packages/website/src/app/styles.module.css
@@ -16,7 +16,7 @@
 }
 
 .middle {
-  display:flex;
+  display: flex;
   flex: 1;
 }
 
@@ -31,6 +31,12 @@
 .mainContent {
   flex: 1;
   overflow-y: auto;
+}
+
+.mainContent ul li {
+  display: list-item;
+  padding-left: 1.5em;
+  text-indent: -1.5em;
 }
 
 .pageFooter {


### PR DESCRIPTION
## Pull request overview

This PR addresses bullet point text wrapping within the website’s `.mainContent` area by adjusting list-item indentation so wrapped lines align consistently with the list text.

**Changes:**
- Normalized CSS formatting for `.middle` (`display: flex;`).
- Added `.mainContent ul li` styling to control list-item indentation via `padding-left` and negative `text-indent`.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v5.7.1-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `website`
    - 218859 [BUG] Bullet point text wrapping [#511](https://github.com/UKHO/admiralty-design-system/pull/511) (mohamme15315@mastek.com [@mohamme15315](https://github.com/mohamme15315))
  
  #### Authors: 2
  
  - [@mohamme15315](https://github.com/mohamme15315)
  - Mohammed Khan (mohamme15315@mastek.com)
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
