### PR TITLE
Switching from JohnstonITC to Inter

### DIFF
--- a/packages/core/src/styles/css/core.scss
+++ b/packages/core/src/styles/css/core.scss
@@ -1,7 +1,7 @@
 @import '../vars/colours';
 @import '../utils/colour-functions';
 // JohnstonITCPro font imported from CDN
-@import url('https://cdn.fonts.net/kit/aa1c2560-9670-43e2-85b0-f27b25f69c56/aa1c2560-9670-43e2-85b0-f27b25f69c56_enhanced.css');
+@import url('https://rsms.me/inter/inter.css');
 
 // Reset browser defaults
 * {
@@ -14,7 +14,10 @@
 // -----------------
 
 html {
-  --admiralty-font-family: 'JohnstonITCPro', Helvetica, sans-serif;
+  --admiralty-font-family: Inter, Arial, sans-serif;
+  @supports (font-variation-settings: normal) {
+    --admiralty-font-family: InterVariable, Arial, sans-serif;
+  }
   --admiralty-font-weight: var(--admiralty-font-weight-normal);
   --admiralty-font-size: 18px;
   --admiralty-line-height: 24px;

--- a/packages/core/src/themes/default.css
+++ b/packages/core/src/themes/default.css
@@ -112,9 +112,9 @@
   --admiralty-font-size-7: 3.5rem;
 
   /** Font Weight **/
-  --admiralty-font-weight-light: 200;
-  --admiralty-font-weight-normal: 300;
-  --admiralty-font-weight-medium: 400;
+  --admiralty-font-weight-light: 300;
+  --admiralty-font-weight-normal: 400;
+  --admiralty-font-weight-medium: 500;
   --admiralty-font-weight-bold: 700;
 
   /** Spacing **/


### PR DESCRIPTION
This pull request updates the core font used across the application from JohnstonITCPro to Inter, including both the standard and variable font versions where supported. It also adjusts the default font weights to match the Inter font's weight scale for improved consistency and readability.

**Font family updates:**

* Changed the main font import in `core.scss` from JohnstonITCPro (via CDN) to Inter (via rsms.me), and updated the CSS variable `--admiralty-font-family` to use Inter and InterVariable where supported. [[1]](diffhunk://#diff-adff38efd958a2630b4562240993f7a14481ba7695eeabc73bc088a0995a3791L4-R4) [[2]](diffhunk://#diff-adff38efd958a2630b4562240993f7a14481ba7695eeabc73bc088a0995a3791L17-R20)

**Font weight adjustments:**

* Updated the default font weight variables in `default.css` to better align with Inter's weight scale (`light` from 200→300, `normal` from 300→400, `medium` from 400→500).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.7.1--canary.513.2519168.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@5.7.1--canary.513.2519168.0
  npm install @ukho/admiralty-core@5.7.1--canary.513.2519168.0
  npm install @ukho-internal/admiralty-docs@5.7.1--canary.513.2519168.0
  npm install @ukho/admiralty-react@5.7.1--canary.513.2519168.0
  npm install test-app@5.7.1--canary.513.2519168.0
  npm install website@5.7.1--canary.513.2519168.0
  # or 
  yarn add @ukho/admiralty-angular@5.7.1--canary.513.2519168.0
  yarn add @ukho/admiralty-core@5.7.1--canary.513.2519168.0
  yarn add @ukho-internal/admiralty-docs@5.7.1--canary.513.2519168.0
  yarn add @ukho/admiralty-react@5.7.1--canary.513.2519168.0
  yarn add test-app@5.7.1--canary.513.2519168.0
  yarn add website@5.7.1--canary.513.2519168.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
