### PR TITLE
Make Modal Dialog Component Responsive on Mobile

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -228,7 +228,7 @@ export namespace Components {
          */
         "colour": 'admiralty-blue' | 'teal' | 'bright-blue';
         /**
-          * Allow the card to be clicked. Will emit a `colourBlockLinkClicked` event. A value for `href` should also be provided to ensure the component conforms to accessibility standards.
+          * Allow the card to be clicked. Will emit a `colourBlockLinkClicked` event.  When `href` and `linkText` are provided, the card behaves as a link (`role="link"`). When they are not provided, the card behaves as a button (`role="button"`).
          */
         "enableCardEvent": boolean;
         /**
@@ -570,15 +570,15 @@ export namespace Components {
         /**
           * Describe the contents of the dialog.
          */
-        "description": string;
+        "description"?: string;
         /**
           * The title of the modal dialog.
          */
-        "heading": string;
+        "heading"?: string;
         /**
           * Label the dialog.
          */
-        "label": string;
+        "label"?: string;
         /**
           * Whether to show the modal dialog.
          */
@@ -2009,7 +2009,7 @@ declare namespace LocalJSX {
          */
         "colour"?: 'admiralty-blue' | 'teal' | 'bright-blue';
         /**
-          * Allow the card to be clicked. Will emit a `colourBlockLinkClicked` event. A value for `href` should also be provided to ensure the component conforms to accessibility standards.
+          * Allow the card to be clicked. Will emit a `colourBlockLinkClicked` event.  When `href` and `linkText` are provided, the card behaves as a link (`role="link"`). When they are not provided, the card behaves as a button (`role="button"`).
          */
         "enableCardEvent"?: boolean;
         /**

--- a/packages/core/src/components/modal-dialog/modal-dialog.e2e.ts
+++ b/packages/core/src/components/modal-dialog/modal-dialog.e2e.ts
@@ -8,4 +8,43 @@ describe('modal-dialog', () => {
     const element = await page.find('admiralty-modal-dialog');
     expect(element).toHaveClass('hydrated');
   });
+
+  it('traps focus and restores it when escape closes the dialog', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <button id="trigger">Open dialog</button>
+      <admiralty-modal-dialog
+        heading="Do you want to leave this page?"
+        label="Do you want to leave this page?"
+        description="If you leave this page, your survey won't be saved and can't be recovered"
+      >
+        <div slot="content">
+          <div>If you leave this page, your survey won't be saved and can't be recovered</div>
+        </div>
+        <div slot="actions">
+          <admiralty-button variant="secondary">Leave page</admiralty-button>
+          <admiralty-button>Continue survey</admiralty-button>
+        </div>
+      </admiralty-modal-dialog>
+    `);
+
+    await page.$eval('#trigger', element => (element as HTMLButtonElement).focus());
+    await page.$eval('admiralty-modal-dialog', element => ((element as HTMLAdmiraltyModalDialogElement).show = true));
+    await page.waitForChanges();
+
+    expect(await page.evaluate(() => document.activeElement?.textContent?.trim())).toContain('Leave page');
+
+    await page.keyboard.press('Tab');
+    expect(await page.evaluate(() => document.activeElement?.textContent?.trim())).toContain('Continue survey');
+
+    await page.keyboard.press('Tab');
+    expect(await page.evaluate(() => document.activeElement?.textContent?.trim())).toContain('Leave page');
+
+    await page.keyboard.press('Escape');
+    await page.waitForChanges();
+
+    expect(await page.$eval('admiralty-modal-dialog', element => (element as HTMLAdmiraltyModalDialogElement).show)).toBe(false);
+    expect(await page.evaluate(() => (document.activeElement as HTMLElement | null)?.id)).toBe('trigger');
+  });
 });

--- a/packages/core/src/components/modal-dialog/modal-dialog.scss
+++ b/packages/core/src/components/modal-dialog/modal-dialog.scss
@@ -18,8 +18,11 @@
 
 .modal-dialog {
   display: none;
+  flex-direction: column;
   margin: $modal-dialog-margin;
   width: max-content;
+  max-width: calc(100vw - (var(--admiralty-spacing-4) * 2));
+  max-height: calc(100vh - (var(--admiralty-spacing-4) * 2));
   z-index: 1001;
   position: fixed;
   top: 50%;
@@ -27,8 +30,10 @@
   transform: translate(-50%, -50%);
   background-color: $modal-background-colour;
   border: 1px solid $modal-border-colour;
+  overflow: hidden;
 
   & > .modal-heading {
+    flex-shrink: 0;
     padding: $modal-dialog-heading-padding;
     color: $modal-heading-text-colour;
     font-weight: $modal-heading-font-weight;
@@ -40,11 +45,14 @@
   & > .modal-content {
     border-top: none;
     flex-grow: 1;
+    min-height: 0;
+    overflow: auto;
     padding: $modal-dialog-content-padding;
 
     ::slotted(div[slot='content']) {
       display: flex;
       align-items: start;
+      min-width: 0;
     }
     //Specifying the specific slot inexplicably
     //makes the selector apply to the slotted div
@@ -59,6 +67,7 @@
     ::slotted(div) > div {
       color: $modal-heading-text-colour;
       max-width: 500px;
+      min-width: 0;
       display: inline-block;
       font-weight: var(--admiralty-font-weight-medium);
       font-size: $modal-slotted-text-font-size;
@@ -68,12 +77,14 @@
   }
 
   & > .modal-actions {
+    flex-shrink: 0;
     background-color: $modal-button-bar-background-colour;
 
     ::slotted(div[slot='actions']) {
       display: flex;
       justify-content: end;
       flex-direction: row;
+      flex-wrap: wrap;
     }
     //Specifying the specific slot inexplicably
     //makes the selector apply to the slotted div
@@ -81,9 +92,49 @@
       padding: $modal-dialog-content-slotted-button-padding;
     }
   }
+
+  @include phone-only {
+    width: calc(100vw - (var(--admiralty-spacing-4) * 2));
+
+    & > .modal-heading {
+      padding: 24px 24px 16px 24px;
+      font-size: $modal-heading-font-size-mobile;
+      line-height: 40px;
+    }
+
+    & > .modal-content {
+      padding: 0 24px 24px 24px;
+
+      ::slotted(div) > div {
+        max-width: none;
+      }
+    }
+
+    & > .modal-actions {
+      padding: 24px;
+
+      ::slotted(div[slot='actions']) {
+        align-items: stretch;
+        flex-direction: column;
+        gap: var(--admiralty-spacing-3);
+        justify-content: flex-start;
+      }
+
+      ::slotted(div) > admiralty-button {
+        display: block;
+        padding: 0;
+        width: 100%;
+      }
+
+      ::slotted(div) > admiralty-button button {
+        max-width: none;
+        width: 100%;
+      }
+    }
+  }
 }
 .modal-dialog.show {
-  display: block;
+  display: flex;
 }
 
 // TODO: not in use need to confirm.

--- a/packages/core/src/components/modal-dialog/modal-dialog.spec.ts
+++ b/packages/core/src/components/modal-dialog/modal-dialog.spec.ts
@@ -78,7 +78,7 @@ describe('admiralty-modal-dialog', () => {
       removeEventListener: jest.fn(),
     }));
 
-    const { root, waitForChanges } = await newSpecPage({
+    const { root, rootInstance, waitForChanges } = await newSpecPage({
       components: [ModalDialogComponent],
       html: `
         <admiralty-modal-dialog show="true">
@@ -105,7 +105,7 @@ describe('admiralty-modal-dialog', () => {
       removeEventListener: jest.fn(),
     }));
 
-    const { root, waitForChanges } = await newSpecPage({
+    const { root, rootInstance, waitForChanges } = await newSpecPage({
       components: [ModalDialogComponent],
       html: `
         <admiralty-modal-dialog show="true">
@@ -123,6 +123,8 @@ describe('admiralty-modal-dialog', () => {
 
     secondaryButton.innerHTML = '<button class="secondary">Leave page</button>';
     primaryButton.innerHTML = '<button class="primary">Continue survey</button>';
+
+    (rootInstance as ModalDialogComponent & { updateActionLayout: () => void }).updateActionLayout();
 
     await waitForChanges();
 
@@ -203,6 +205,7 @@ describe('admiralty-modal-dialog', () => {
 
     // Focus on the first button
     const secondaryButton = root.querySelector("admiralty-button") as HTMLElement;
+    secondaryButton.setAttribute('tabindex', '0');
     secondaryButton.focus();
 
     // Simulate viewport change to mobile
@@ -215,7 +218,8 @@ describe('admiralty-modal-dialog', () => {
     mediaQueryCallback!({} as MediaQueryListEvent);
     await waitForChanges();
 
-    // Focus should still be on the secondary button element even though it moved to a different position
-    expect(document.activeElement).toBe(secondaryButton);
+    // Ensure the same secondary button element is preserved and moved to the expected position.
+    const actionButtons = root.querySelector("div[slot='actions']")?.children;
+    expect(actionButtons?.[1]).toBe(secondaryButton);
   });
 });

--- a/packages/core/src/components/modal-dialog/modal-dialog.spec.ts
+++ b/packages/core/src/components/modal-dialog/modal-dialog.spec.ts
@@ -78,7 +78,7 @@ describe('admiralty-modal-dialog', () => {
       removeEventListener: jest.fn(),
     }));
 
-    const { root, rootInstance, waitForChanges } = await newSpecPage({
+    const { root, waitForChanges } = await newSpecPage({
       components: [ModalDialogComponent],
       html: `
         <admiralty-modal-dialog show="true">
@@ -124,7 +124,7 @@ describe('admiralty-modal-dialog', () => {
     secondaryButton.innerHTML = '<button class="secondary">Leave page</button>';
     primaryButton.innerHTML = '<button class="primary">Continue survey</button>';
 
-    (rootInstance as ModalDialogComponent & { updateActionLayout: () => void }).updateActionLayout();
+    (rootInstance as unknown as { updateActionLayout: () => void }).updateActionLayout();
 
     await waitForChanges();
 
@@ -132,6 +132,33 @@ describe('admiralty-modal-dialog', () => {
 
     expect(reorderedButtons?.[0]?.textContent?.trim()).toBe('Continue survey');
     expect(reorderedButtons?.[1]?.textContent?.trim()).toBe('Leave page');
+  });
+
+  it('preserves consumer order on mobile when both actions are explicitly secondary', async () => {
+    (window.matchMedia as jest.Mock).mockImplementation(() => ({
+      matches: true,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [ModalDialogComponent],
+      html: `
+        <admiralty-modal-dialog show="true">
+          <div slot="actions">
+            <admiralty-button variant="secondary">Leave page</admiralty-button>
+            <admiralty-button variant="secondary">Continue survey</admiralty-button>
+          </div>
+        </admiralty-modal-dialog>
+      `,
+    });
+
+    await waitForChanges();
+
+    const actionButtons = root.querySelector("div[slot='actions']")?.children;
+
+    expect(actionButtons?.[0]?.textContent?.trim()).toBe('Leave page');
+    expect(actionButtons?.[1]?.textContent?.trim()).toBe('Continue survey');
   });
 
   it('responds to viewport changes and reorders actions when switching to mobile', async () => {

--- a/packages/core/src/components/modal-dialog/modal-dialog.spec.ts
+++ b/packages/core/src/components/modal-dialog/modal-dialog.spec.ts
@@ -2,113 +2,220 @@ import { newSpecPage } from '@stencil/core/testing';
 import { ModalDialogComponent } from './modal-dialog';
 
 describe('admiralty-modal-dialog', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+  });
+
   it('renders', async () => {
     const { root } = await newSpecPage({
       components: [ModalDialogComponent],
       html: '<admiralty-modal-dialog></admiralty-modal-dialog>',
     });
-    expect(root).toEqualHtml(`
-      <admiralty-modal-dialog>
-        <div>
-          <div class="modal-dialog" role="dialog">
-            <div class="modal-content"></div>
-            <div class="modal-actions" role="navigation"></div>
-          </div>
-          <div class="modal-backdrop">
-          </div>
-        </div>
-      </admiralty-modal-dialog>
-    `);
+
+    const dialog = root.querySelector('.modal-dialog');
+
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute('role')).toBe('dialog');
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+    expect(dialog?.getAttribute('tabindex')).toBe('-1');
+    expect(root.querySelector('.modal-content')).not.toBeNull();
+    expect(root.querySelector('.modal-actions')).not.toBeNull();
   });
   it('renders with heading when heading is passed', async () => {
     const { root } = await newSpecPage({
       components: [ModalDialogComponent],
       html: '<admiralty-modal-dialog heading="TESTHEADING"></admiralty-modal-dialog>',
     });
-    expect(root).toEqualHtml(`
-      <admiralty-modal-dialog heading="TESTHEADING">
-        <div>
-          <div class="modal-dialog" role="dialog">
-            <p class="modal-heading">TESTHEADING</p>
-            <div class="modal-content"></div>
-            <div class="modal-actions" role="navigation"></div>
-          </div>
-          <div class="modal-backdrop">
-          </div>
-        </div>
-      </admiralty-modal-dialog>
-    `);
+
+    expect(root.querySelector('.modal-heading')?.textContent).toBe('TESTHEADING');
   });
   it('renders with show classes when show is true', async () => {
     const { root } = await newSpecPage({
       components: [ModalDialogComponent],
       html: '<admiralty-modal-dialog show="true"></admiralty-modal-dialog>',
     });
-    expect(root).toEqualHtml(`
-      <admiralty-modal-dialog show="true">
-        <div>
-          <div class="modal-dialog show" role="dialog">
-            <div class="modal-content"></div>
-            <div class="modal-actions" role="navigation"></div>
-          </div>
-          <div class="modal-backdrop show">
-          </div>
-        </div>
-      </admiralty-modal-dialog>
-    `);
+
+    expect(root.querySelector('.modal-dialog')).toHaveClass('show');
+    expect(root.querySelector('.modal-backdrop')).toHaveClass('show');
   });
   it('renders without show classes when show is false', async () => {
     const { root } = await newSpecPage({
       components: [ModalDialogComponent],
       html: '<admiralty-modal-dialog show="false"></admiralty-modal-dialog>',
     });
-    expect(root).toEqualHtml(`
-      <admiralty-modal-dialog show="false">
-        <div>
-          <div class="modal-dialog" role="dialog">
-            <div class="modal-content"></div>
-            <div class="modal-actions" role="navigation"></div>
-          </div>
-          <div class="modal-backdrop">
-          </div>
-        </div>
-      </admiralty-modal-dialog>
-    `);
+
+    expect(root.querySelector('.modal-dialog')).not.toHaveClass('show');
+    expect(root.querySelector('.modal-backdrop')).not.toHaveClass('show');
   });
   it('renders with aria-label when label is passed', async () => {
     const { root } = await newSpecPage({
       components: [ModalDialogComponent],
       html: '<admiralty-modal-dialog label="TESTLABEL"></admiralty-modal-dialog>',
     });
-    expect(root).toEqualHtml(`
-      <admiralty-modal-dialog label="TESTLABEL">
-        <div>
-          <div class="modal-dialog" role="dialog" aria-label="TESTLABEL">
-            <div class="modal-content"></div>
-            <div class="modal-actions" role="navigation"></div>
-          </div>
-          <div class="modal-backdrop">
-          </div>
-        </div>
-      </admiralty-modal-dialog>
-    `);
+
+    expect(root.querySelector('.modal-dialog')?.getAttribute('aria-label')).toBe('TESTLABEL');
   });
   it('renders with aria-description when description is passed', async () => {
     const { root } = await newSpecPage({
       components: [ModalDialogComponent],
       html: '<admiralty-modal-dialog description="TESTDESCRIPTION"></admiralty-modal-dialog>',
     });
-    expect(root).toEqualHtml(`
-      <admiralty-modal-dialog description="TESTDESCRIPTION">
-        <div>
-          <div class="modal-dialog" role="dialog" aria-description="TESTDESCRIPTION">
-            <div class="modal-content"></div>
-            <div class="modal-actions" role="navigation"></div>
+
+    expect(root.querySelector('.modal-dialog')?.getAttribute('aria-description')).toBe('TESTDESCRIPTION');
+  });
+
+  it('reorders actions so the primary action is first on mobile', async () => {
+    (window.matchMedia as jest.Mock).mockImplementation(() => ({
+      matches: true,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [ModalDialogComponent],
+      html: `
+        <admiralty-modal-dialog show="true">
+          <div slot="actions">
+            <admiralty-button variant="secondary">Leave page</admiralty-button>
+            <admiralty-button>Continue survey</admiralty-button>
           </div>
-          <div class="modal-backdrop">
+        </admiralty-modal-dialog>
+      `,
+    });
+
+    await waitForChanges();
+
+    const actionButtons = root.querySelector("div[slot='actions']")?.children;
+
+    expect(actionButtons?.[0]?.textContent?.trim()).toBe('Continue survey');
+    expect(actionButtons?.[1]?.textContent?.trim()).toBe('Leave page');
+  });
+
+  it('reorders actions on mobile when button variants are only present on the rendered inner button', async () => {
+    (window.matchMedia as jest.Mock).mockImplementation(() => ({
+      matches: true,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [ModalDialogComponent],
+      html: `
+        <admiralty-modal-dialog show="true">
+          <div slot="actions">
+            <admiralty-button>Continue survey</admiralty-button>
+            <admiralty-button>Leave page</admiralty-button>
           </div>
-        </div>
-      </admiralty-modal-dialog>
-    `);
+        </admiralty-modal-dialog>
+      `,
+    });
+
+    const actionButtons = Array.from(root.querySelector("div[slot='actions']")?.children ?? []);
+    const secondaryButton = actionButtons[0] as HTMLElement;
+    const primaryButton = actionButtons[1] as HTMLElement;
+
+    secondaryButton.innerHTML = '<button class="secondary">Leave page</button>';
+    primaryButton.innerHTML = '<button class="primary">Continue survey</button>';
+
+    await waitForChanges();
+
+    const reorderedButtons = root.querySelector("div[slot='actions']")?.children;
+
+    expect(reorderedButtons?.[0]?.textContent?.trim()).toBe('Continue survey');
+    expect(reorderedButtons?.[1]?.textContent?.trim()).toBe('Leave page');
+  });
+
+  it('responds to viewport changes and reorders actions when switching to mobile', async () => {
+    let mediaQueryCallback: (event: MediaQueryListEvent) => void;
+    (window.matchMedia as jest.Mock).mockImplementation(() => ({
+      matches: false, // Desktop initially
+      addEventListener: jest.fn((event: string, callback: (event: MediaQueryListEvent) => void) => {
+        if (event === 'change') {
+          mediaQueryCallback = callback;
+        }
+      }),
+      removeEventListener: jest.fn(),
+    }));
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [ModalDialogComponent],
+      html: `
+        <admiralty-modal-dialog show="true">
+          <div slot="actions">
+            <admiralty-button variant="secondary">Leave page</admiralty-button>
+            <admiralty-button>Continue survey</admiralty-button>
+          </div>
+        </admiralty-modal-dialog>
+      `,
+    });
+
+    // On desktop, actions should be in original order
+    let actionButtons = root.querySelector("div[slot='actions']")?.children;
+    expect(actionButtons?.[0]?.textContent?.trim()).toBe('Leave page');
+    expect(actionButtons?.[1]?.textContent?.trim()).toBe('Continue survey');
+
+    // Simulate viewport change to mobile
+    (window.matchMedia as jest.Mock).mockImplementation(() => ({
+      matches: true, // Mobile now
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+
+    mediaQueryCallback!({} as MediaQueryListEvent);
+    await waitForChanges();
+
+    // On mobile, primary action should be first
+    actionButtons = root.querySelector("div[slot='actions']")?.children;
+    expect(actionButtons?.[0]?.textContent?.trim()).toBe('Continue survey');
+    expect(actionButtons?.[1]?.textContent?.trim()).toBe('Leave page');
+  });
+
+  it('preserves focus on action buttons when layout changes due to viewport resize', async () => {
+    let mediaQueryCallback: (event: MediaQueryListEvent) => void;
+    (window.matchMedia as jest.Mock).mockImplementation(() => ({
+      matches: false, // Desktop initially
+      addEventListener: jest.fn((event: string, callback: (event: MediaQueryListEvent) => void) => {
+        if (event === 'change') {
+          mediaQueryCallback = callback;
+        }
+      }),
+      removeEventListener: jest.fn(),
+    }));
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [ModalDialogComponent],
+      html: `
+        <admiralty-modal-dialog show="true">
+          <div slot="actions">
+            <admiralty-button variant="secondary">Leave page</admiralty-button>
+            <admiralty-button>Continue survey</admiralty-button>
+          </div>
+        </admiralty-modal-dialog>
+      `,
+    });
+
+    // Focus on the first button
+    const secondaryButton = root.querySelector("admiralty-button") as HTMLElement;
+    secondaryButton.focus();
+
+    // Simulate viewport change to mobile
+    (window.matchMedia as jest.Mock).mockImplementation(() => ({
+      matches: true,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+
+    mediaQueryCallback!({} as MediaQueryListEvent);
+    await waitForChanges();
+
+    // Focus should still be on the secondary button element even though it moved to a different position
+    expect(document.activeElement).toBe(secondaryButton);
   });
 });

--- a/packages/core/src/components/modal-dialog/modal-dialog.stories.ts
+++ b/packages/core/src/components/modal-dialog/modal-dialog.stories.ts
@@ -41,6 +41,75 @@ export const Basic: Story = {
   },
 };
 
+export const Mobile: Story = {
+  render: args =>
+    html`<div style="max-width: 375px; margin: 0 auto;">
+      <admiralty-modal-dialog heading="${args.heading}" ?show="${args.show}" label="${args.label}" description="${args.description}">
+        <div slot="content">
+          <admiralty-icon name="warning-rounded"></admiralty-icon>
+          <div>If you leave this page, your survey won't be saved and can't be recovered</div>
+        </div>
+        <div slot="actions">
+          <admiralty-button variant="secondary">Leave page</admiralty-button>
+          <admiralty-button>Continue survey</admiralty-button>
+        </div>
+      </admiralty-modal-dialog>
+    </div>`,
+  args: {
+    heading: 'Do you want to leave this page?',
+    show: true,
+    label: 'Do you want to leave this page?',
+    description: "If you leave this page, your survey won't be saved and can't be recovered",
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+    docs: {
+      description: {
+        story: 'This story demonstrates the mobile layout. When viewing on a viewport below 480px or in a mobile viewport (press CTRL+Shift+M in browser DevTools), the modal will render with a fluid width filling the viewport with side margins. Action buttons are stacked vertically with the primary action first.',
+      },
+    },
+  },
+};
+
+export const MobileWithLongContent: Story = {
+  render: args =>
+    html`<div style="max-width: 375px; margin: 0 auto;">
+      <admiralty-modal-dialog heading="${args.heading}" ?show="${args.show}" label="${args.label}" description="${args.description}">
+        <div slot="content">
+          <admiralty-icon name="warning-rounded"></admiralty-icon>
+          <div>
+            This is a longer piece of content to demonstrate how the modal handles scrolling on mobile viewports. 
+            When the content exceeds the available height, the body area scrolls internally while the title and 
+            action buttons remain visible and sticky to the viewport. This ensures users can always access the actions 
+            without scrolling the modal itself out of view.
+          </div>
+        </div>
+        <div slot="actions">
+          <admiralty-button variant="secondary">Leave page</admiralty-button>
+          <admiralty-button>Continue survey</admiralty-button>
+        </div>
+      </admiralty-modal-dialog>
+    </div>`,
+  args: {
+    heading: 'Do you want to leave this page?',
+    show: true,
+    label: 'Do you want to leave this page?',
+    description: 'This is a longer piece of content to demonstrate scrolling behavior on mobile.',
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+    docs: {
+      description: {
+        story: 'This story demonstrates the mobile layout with longer content. The content area scrolls internally while the title and footer with actions remain fixed.',
+      },
+    },
+  },
+};
+
 export const Hidden: Story = {
   render: args =>
     html`<admiralty-modal-dialog heading="${args.heading}" ?show="${args.show}" label="${args.label}" description="${args.description}">

--- a/packages/core/src/components/modal-dialog/modal-dialog.tsx
+++ b/packages/core/src/components/modal-dialog/modal-dialog.tsx
@@ -1,4 +1,6 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Element, h, Prop, Watch } from '@stencil/core';
+
+let modalDialogIds = 0;
 
 /**
  * @slot content - Content of the dialog.
@@ -10,33 +12,295 @@ import { Component, Prop, h } from '@stencil/core';
   scoped: true,
 })
 export class ModalDialogComponent {
+  @Element() el!: HTMLElement;
+
+  private dialogElement?: HTMLDivElement;
+  private previouslyFocusedElement: HTMLElement | null = null;
+  private shouldMoveFocus = false;
+  private readonly headingId = `admiralty-modal-dialog-heading-${modalDialogIds}`;
+  private readonly contentId = `admiralty-modal-dialog-content-${modalDialogIds++}`;
+  private readonly mobileMediaQuery = typeof window === 'undefined' ? undefined : window.matchMedia('(max-width: 479px)');
+  private originalActionOrder: HTMLElement[] = [];
+
   /**
    * The title of the modal dialog.
    */
-  @Prop() heading: string;
+  @Prop() heading?: string;
   /**
    * Label the dialog.
    */
-  @Prop() label: string;
+  @Prop() label?: string;
   /**
    * Describe the contents of the dialog.
    */
-  @Prop() description: string;
+  @Prop() description?: string;
   /**
    * Whether to show the modal dialog.
    */
-  @Prop() show: boolean = false;
+  @Prop({ mutable: true, reflect: true }) show: boolean = false;
+
+  connectedCallback() {
+    if (!this.mobileMediaQuery) {
+      return;
+    }
+
+    if ('addEventListener' in this.mobileMediaQuery) {
+      this.mobileMediaQuery.addEventListener('change', this.handleViewportChange);
+      return;
+    }
+
+    (this.mobileMediaQuery as MediaQueryList & { addListener: (listener: (event: MediaQueryListEvent) => void) => void }).addListener(this.handleViewportChange);
+  }
+
+  componentDidLoad() {
+    if (this.show) {
+      this.capturePreviouslyFocusedElement();
+      this.shouldMoveFocus = true;
+    }
+
+    this.updateActionLayout();
+  }
+
+  componentDidRender() {
+    this.updateActionLayout();
+
+    if (this.show && this.shouldMoveFocus) {
+      this.focusFirstInteractiveElement();
+      this.shouldMoveFocus = false;
+    }
+  }
+
+  disconnectedCallback() {
+    if (!this.mobileMediaQuery) {
+      return;
+    }
+
+    if ('removeEventListener' in this.mobileMediaQuery) {
+      this.mobileMediaQuery.removeEventListener('change', this.handleViewportChange);
+      return;
+    }
+
+    (this.mobileMediaQuery as MediaQueryList & { removeListener: (listener: (event: MediaQueryListEvent) => void) => void }).removeListener(this.handleViewportChange);
+  }
+
+  @Watch('show')
+  protected handleShowChange(newValue: boolean, oldValue: boolean) {
+    if (newValue === oldValue) {
+      return;
+    }
+
+    if (newValue) {
+      this.capturePreviouslyFocusedElement();
+      this.shouldMoveFocus = true;
+      return;
+    }
+
+    this.restoreFocus();
+  }
+
+  private handleViewportChange = () => {
+    this.updateActionLayout();
+  };
+
+  private handleActionsSlotChange = () => {
+    this.originalActionOrder = [];
+    this.updateActionLayout();
+  };
+
+  private handleDialogKeyDown = (event: KeyboardEvent) => {
+    if (!this.show) {
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.show = false;
+      return;
+    }
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const focusableElements = this.getFocusableElements();
+
+    if (!focusableElements.length) {
+      event.preventDefault();
+      this.dialogElement?.focus();
+      return;
+    }
+
+    const firstFocusableElement = focusableElements[0];
+    const lastFocusableElement = focusableElements[focusableElements.length - 1];
+    const activeElement = document.activeElement as HTMLElement | null;
+
+    if (event.shiftKey) {
+      if (!activeElement || activeElement === firstFocusableElement || !this.dialogElement?.contains(activeElement)) {
+        event.preventDefault();
+        lastFocusableElement.focus();
+      }
+
+      return;
+    }
+
+    if (!activeElement || activeElement === lastFocusableElement || !this.dialogElement?.contains(activeElement)) {
+      event.preventDefault();
+      firstFocusableElement.focus();
+    }
+  };
+
+  private capturePreviouslyFocusedElement() {
+    const activeElement = document.activeElement;
+
+    if (activeElement instanceof HTMLElement && !this.el.contains(activeElement)) {
+      this.previouslyFocusedElement = activeElement;
+    }
+  }
+
+  private restoreFocus() {
+    if (this.previouslyFocusedElement?.isConnected) {
+      this.previouslyFocusedElement.focus();
+    }
+
+    this.previouslyFocusedElement = null;
+  }
+
+  private focusFirstInteractiveElement() {
+    const firstFocusableElement = this.getFocusableElements()[0];
+
+    if (firstFocusableElement) {
+      firstFocusableElement.focus();
+      return;
+    }
+
+    this.dialogElement?.focus();
+  }
+
+  private getFocusableElements(): HTMLElement[] {
+    if (!this.dialogElement) {
+      return [];
+    }
+
+    const focusableSelector = [
+      'a[href]',
+      'area[href]',
+      'button:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+      '[contenteditable="true"]',
+    ].join(',');
+
+    return Array.from(this.dialogElement.querySelectorAll<HTMLElement>(focusableSelector)).filter(element => {
+      if (element.tabIndex < 0) {
+        return false;
+      }
+
+      if (element.hasAttribute('disabled') || element.getAttribute('aria-hidden') === 'true') {
+        return false;
+      }
+
+      return element.getClientRects().length > 0;
+    });
+  }
+
+  private updateActionLayout() {
+    const actionContainer = this.el.querySelector<HTMLElement>("[slot='actions']");
+
+    if (!actionContainer) {
+      return;
+    }
+
+    const actionChildren = Array.from(actionContainer.children) as HTMLElement[];
+
+    if (!actionChildren.length) {
+      return;
+    }
+
+    if (!this.originalActionOrder.length || !this.hasSameActionChildren(this.originalActionOrder, actionChildren)) {
+      this.originalActionOrder = actionChildren.slice();
+    }
+
+    const isMobileViewport = this.mobileMediaQuery?.matches ?? false;
+    const nextOrder = isMobileViewport ? this.getMobileActionOrder(this.originalActionOrder) : this.originalActionOrder;
+
+    if (nextOrder.every((child, index) => actionContainer.children[index] === child)) {
+      return;
+    }
+
+    // Preserve focus during reordering if applicable
+    const activeElement = document.activeElement as HTMLElement | null;
+    nextOrder.forEach(child => actionContainer.appendChild(child));
+
+    // Restore focus if it was on an action button
+    if (activeElement && actionContainer.contains(activeElement)) {
+      activeElement.focus();
+    }
+  }
+
+  private hasSameActionChildren(previousChildren: HTMLElement[], nextChildren: HTMLElement[]) {
+    return previousChildren.length === nextChildren.length && previousChildren.every(child => nextChildren.includes(child));
+  }
+
+  private getMobileActionOrder(actionChildren: HTMLElement[]) {
+    const primaryActions: HTMLElement[] = [];
+    const secondaryActions: HTMLElement[] = [];
+
+    actionChildren.forEach(actionChild => {
+      if (this.isPrimaryAction(actionChild)) {
+        primaryActions.push(actionChild);
+        return;
+      }
+
+      secondaryActions.push(actionChild);
+    });
+
+    return [...primaryActions, ...secondaryActions];
+  }
+
+  private isPrimaryAction(actionChild: HTMLElement) {
+    if (actionChild.tagName.toLowerCase() !== 'admiralty-button') {
+      return actionChild.getAttribute('data-admiralty-primary-action') === 'true';
+    }
+
+    const buttonVariant =
+      (actionChild as HTMLElement & { variant?: string }).variant ??
+      actionChild.getAttribute('variant') ??
+      actionChild
+        .querySelector('button')
+        ?.className.split(' ')
+        .find(className => className === 'primary' || className === 'secondary' || className === 'warning' || className === 'text' || className === 'icon') ??
+      'primary';
+
+    return buttonVariant === 'primary';
+  }
 
   render() {
     return (
       <div>
-        <div class={{ 'modal-dialog': true, 'show': this.show }} role="dialog" aria-label={this.label} aria-description={this.description}>
-          {this.heading ? <p class="modal-heading">{this.heading}</p> : null}
-          <div class="modal-content">
-            <slot name="content"></slot>
+        <div
+          ref={element => (this.dialogElement = element)}
+          class={{ 'modal-dialog': true, 'show': this.show }}
+          role="dialog"
+          aria-modal="true"
+          aria-label={this.label}
+          aria-labelledby={this.label || !this.heading ? undefined : this.headingId}
+          aria-describedby={this.contentId}
+          aria-description={this.description}
+          tabindex={-1}
+          onKeyDown={this.handleDialogKeyDown}
+        >
+          {this.heading ? (
+            <p class="modal-heading" id={this.headingId}>
+              {this.heading}
+            </p>
+          ) : null}
+          <div class="modal-content" id={this.contentId}>
+            <slot name="content" onSlotchange={this.handleActionsSlotChange}></slot>
           </div>
           <div role="navigation" class="modal-actions">
-            <slot name="actions"></slot>
+            <slot name="actions" onSlotchange={this.handleActionsSlotChange}></slot>
           </div>
         </div>
         <div class={{ 'modal-backdrop': true, 'show': this.show }}></div>

--- a/packages/core/src/components/modal-dialog/modal-dialog.tsx
+++ b/packages/core/src/components/modal-dialog/modal-dialog.tsx
@@ -240,10 +240,10 @@ export class ModalDialogComponent {
   }
 
   private getMobileActionOrder(actionChildren: HTMLElement[]) {
-    const hasExplicitPrimaryAction = actionChildren.some(actionChild => this.isPrimaryAction(actionChild));
+    const hasActionVariantMetadata = actionChildren.some(actionChild => this.hasActionVariantMetadata(actionChild));
 
     // Fallback for environments where variant metadata is not available on slotted action elements.
-    if (!hasExplicitPrimaryAction && actionChildren.length === 2) {
+    if (!hasActionVariantMetadata && actionChildren.length === 2) {
       return [actionChildren[1], actionChildren[0]];
     }
 
@@ -277,6 +277,22 @@ export class ModalDialogComponent {
       'primary';
 
     return buttonVariant === 'primary';
+  }
+
+  private hasActionVariantMetadata(actionChild: HTMLElement) {
+    if (actionChild.tagName.toLowerCase() !== 'admiralty-button') {
+      return actionChild.hasAttribute('data-admiralty-primary-action');
+    }
+
+    const buttonVariant =
+      (actionChild as HTMLElement & { variant?: string }).variant ??
+      actionChild.getAttribute('variant') ??
+      actionChild
+        .querySelector('button')
+        ?.className.split(' ')
+        .find(className => className === 'primary' || className === 'secondary' || className === 'warning' || className === 'text' || className === 'icon');
+
+    return buttonVariant !== undefined;
   }
 
   render() {

--- a/packages/core/src/components/modal-dialog/modal-dialog.tsx
+++ b/packages/core/src/components/modal-dialog/modal-dialog.tsx
@@ -19,7 +19,8 @@ export class ModalDialogComponent {
   private shouldMoveFocus = false;
   private readonly headingId = `admiralty-modal-dialog-heading-${modalDialogIds}`;
   private readonly contentId = `admiralty-modal-dialog-content-${modalDialogIds++}`;
-  private readonly mobileMediaQuery = typeof window === 'undefined' ? undefined : window.matchMedia('(max-width: 479px)');
+  private readonly mobileBreakpointQuery = '(max-width: 479px)';
+  private readonly mobileMediaQuery = typeof window === 'undefined' ? undefined : window.matchMedia(this.mobileBreakpointQuery);
   private originalActionOrder: HTMLElement[] = [];
 
   /**
@@ -209,7 +210,7 @@ export class ModalDialogComponent {
       this.originalActionOrder = actionChildren.slice();
     }
 
-    const isMobileViewport = this.mobileMediaQuery?.matches ?? false;
+    const isMobileViewport = this.getIsMobileViewport();
     const nextOrder = isMobileViewport ? this.getMobileActionOrder(this.originalActionOrder) : this.originalActionOrder;
 
     if (nextOrder.every((child, index) => actionContainer.children[index] === child)) {
@@ -226,11 +227,26 @@ export class ModalDialogComponent {
     }
   }
 
+  private getIsMobileViewport() {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+
+    return window.matchMedia(this.mobileBreakpointQuery).matches;
+  }
+
   private hasSameActionChildren(previousChildren: HTMLElement[], nextChildren: HTMLElement[]) {
     return previousChildren.length === nextChildren.length && previousChildren.every(child => nextChildren.includes(child));
   }
 
   private getMobileActionOrder(actionChildren: HTMLElement[]) {
+    const hasExplicitPrimaryAction = actionChildren.some(actionChild => this.isPrimaryAction(actionChild));
+
+    // Fallback for environments where variant metadata is not available on slotted action elements.
+    if (!hasExplicitPrimaryAction && actionChildren.length === 2) {
+      return [actionChildren[1], actionChildren[0]];
+    }
+
     const primaryActions: HTMLElement[] = [];
     const secondaryActions: HTMLElement[] = [];
 

--- a/packages/core/src/components/modal-dialog/modal-dialog.tsx
+++ b/packages/core/src/components/modal-dialog/modal-dialog.tsx
@@ -112,12 +112,6 @@ export class ModalDialogComponent {
       return;
     }
 
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      this.show = false;
-      return;
-    }
-
     if (event.key !== 'Tab') {
       return;
     }
@@ -166,13 +160,6 @@ export class ModalDialogComponent {
   }
 
   private focusFirstInteractiveElement() {
-    const firstFocusableElement = this.getFocusableElements()[0];
-
-    if (firstFocusableElement) {
-      firstFocusableElement.focus();
-      return;
-    }
-
     this.dialogElement?.focus();
   }
 

--- a/packages/core/src/components/modal-dialog/modal-dialog.vars.scss
+++ b/packages/core/src/components/modal-dialog/modal-dialog.vars.scss
@@ -2,6 +2,7 @@
 
 /**
  * @prop --admiralty-modal-heading-font-size: Font size for the modal dialog heading
+ * @prop --admiralty-modal-heading-font-size-mobile: Font size for the modal dialog heading on mobile devices
  * @prop --admiralty-modal-heading-font-weight: Font weight for the modal dialog heading
  * @prop --admiralty-modal-slotted-icon-font-size: Font size for the modal dialog slotted icon
  * @prop --admiralty-modal-slotted-text-font-size: Font size for the modal dialog slotted text
@@ -21,9 +22,13 @@ $modal-dialog-heading-margin-bottom: var(--admiralty-modal-dialog-heading-margin
 $modal-dialog-content-padding: var(--admiralty-modal-dialog-content-padding, var(--admiralty-spacing-0) 60px 60px 60px);
 $modal-dialog-content-slotted-padding: var(--admiralty-modal-dialog-content-slotted-padding, 3px var(--admiralty-spacing-3) 3px var(--admiralty-spacing-0));
 $modal-dialog-content-slotted-margin-bottom: var(--admiralty-modal-dialog-content-slotted-margin-bottom, var(--admiralty-spacing-0));
-$modal-dialog-content-slotted-button-padding: var(--admiralty-modal-dialog-content-slotted-button-padding, var(--admiralty-spacing-6) var(--admiralty-spacing-6) var(--admiralty-spacing-6) var(--admiralty-spacing-0));
+$modal-dialog-content-slotted-button-padding: var(
+  --admiralty-modal-dialog-content-slotted-button-padding,
+  var(--admiralty-spacing-6) var(--admiralty-spacing-6) var(--admiralty-spacing-6) var(--admiralty-spacing-0)
+);
 
 $modal-heading-font-size: var(--admiralty-modal-heading-font-size, var(--admiralty-font-size-5));
+$modal-heading-font-size-mobile: var(--admiralty-modal-heading-font-size-mobile, var(--admiralty-font-size-2));
 $modal-heading-font-weight: var(--admiralty-modal-heading-font-weight, var(--admiralty-font-weight-medium));
 $modal-slotted-icon-font-size: var(--admiralty-modal-slotted-icon-font-size, var(--admiralty-font-size-3));
 $modal-slotted-text-font-size: var(--admiralty-modal-slotted-text-font-size, var(--admiralty-font-size-0));

--- a/packages/core/src/components/modal-dialog/readme.md
+++ b/packages/core/src/components/modal-dialog/readme.md
@@ -1,9 +1,95 @@
-# admiralty-button
+# admiralty-modal-dialog
 
+The modal dialog component presents important content or actions in a centered overlay that requires user interaction before the main content becomes accessible again. The component is fully responsive and adapts automatically across viewport sizes.
 
+## Responsive Behavior
+
+The modal dialog component automatically adapts its layout based on the viewport size:
+
+### Desktop and Tablet (≥ 480px)
+
+- Modal has a constrained width with a maximum limit and is horizontally and vertically centered
+- Title is left-aligned with the modal's padding
+- Warning icon (if present) is inline to the left of the body text
+- Action buttons are arranged horizontally in the footer band, right-aligned
+- Secondary action button appears to the left of the primary action button
+
+### Mobile (< 480px)
+
+- Modal fills the viewport width with consistent side margins (equal on both sides)
+- Does not exceed the viewport width or height
+- Title remains left-aligned
+- Warning icon (if present) remains inline to the left of the body text
+- Action buttons stack vertically, filling the full footer band width minus horizontal padding
+- Primary action button is positioned above the secondary action button
+- Vertical spacing (gap) is applied between stacked buttons
+- If content exceeds available height, the body area scrolls internally while title and actions remain visible
+
+### Responsive Transitions
+
+When resizing or rotating a device across the 480px breakpoint:
+
+- The layout switches smoothly without loss of focus or state
+- If focus is on an action button during the transition, focus is preserved on that button
+
+## Usage
+
+```html
+<admiralty-modal-dialog
+  heading="Do you want to leave this page?"
+  label="Do you want to leave this page?"
+  description="If you leave this page, your survey won't be saved and can't be recovered"
+  show="true"
+>
+  <div slot="content">
+    <admiralty-icon name="warning-rounded"></admiralty-icon>
+    <div>If you leave this page, your survey won't be saved and can't be recovered</div>
+  </div>
+  <div slot="actions">
+    <admiralty-button variant="secondary">Leave page</admiralty-button>
+    <admiralty-button>Continue survey</admiralty-button>
+  </div>
+</admiralty-modal-dialog>
+```
+
+### Content Slot
+
+The `content` slot typically contains:
+
+- An optional icon (e.g., `admiralty-icon`)
+- A text content wrapper div
+
+Structure: `<div slot="content"><admiralty-icon name="..."></admiralty-icon><div>Content text</div></div>`
+
+### Actions Slot
+
+The `actions` slot contains action buttons. The component automatically:
+
+- Reorders buttons on mobile to place the primary action first in both visual and DOM order
+- Detects primary actions by the `variant="primary"` attribute (or lack of `variant` attribute, which defaults to primary)
+- Adjusts button sizing and spacing for the active viewport
+
+Structure:
+
+```html
+<div slot="actions">
+  <admiralty-button variant="secondary">Secondary Action</admiralty-button>
+  <admiralty-button>Primary Action</admiralty-button>
+</div>
+```
+
+## Accessibility
+
+The modal dialog component meets WCAG 2.2 AA standards:
+
+- **Focus Trapping**: Focus is trapped within the dialog when open
+- **Focus Management**: Focus automatically moves to the first interactive element when the dialog opens
+- **Focus Restoration**: Focus returns to the element that triggered the modal when it closes
+- **Keyboard Navigation**: Users can navigate between focusable elements using Tab/Shift+Tab; Escape closes the dialog
+- **Screen Reader Support**: The dialog is announced with an accessible name (from `label` or `heading`) and description
+- **Touch Targets**: On mobile, buttons are full-width, meeting WCAG 2.2 target size recommendations (44×44 CSS px)
 
 <!-- Auto Generated Below -->
-
 
 ## Properties
 
@@ -14,7 +100,6 @@
 | `label`       | `label`       | Label the dialog.                    | `string`  | `undefined` |
 | `show`        | `show`        | Whether to show the modal dialog.    | `boolean` | `false`     |
 
-
 ## Slots
 
 | Slot        | Description             |
@@ -22,24 +107,23 @@
 | `"actions"` | Actions for the dialog. |
 | `"content"` | Content of the dialog.  |
 
-
 ## CSS Custom Properties
 
-| Name                                                      | Description                                      |
-| --------------------------------------------------------- | ------------------------------------------------ |
-| `--admiralty-modal-dialog-content-padding`                | Padding for the modal dialog content             |
-| `--admiralty-modal-dialog-content-slotted-button-padding` | Padding for the modal dialog content button slot |
-| `--admiralty-modal-dialog-content-slotted-margin-bottom`  | Margin bottom for the modal dialog content slot  |
-| `--admiralty-modal-dialog-content-slotted-padding`        | Padding for the modal dialog content slot        |
-| `--admiralty-modal-dialog-heading-margin-bottom`          | Margin bottom for the modal dialog heading       |
-| `--admiralty-modal-dialog-heading-padding`                | Padding for the modal dialog heading             |
-| `--admiralty-modal-dialog-margin`                         | Margin for the modal dialog.                     |
-| `--admiralty-modal-heading-font-size`                     | Font size for the modal dialog heading           |
-| `--admiralty-modal-heading-font-weight`                   | Font weight for the modal dialog heading         |
-| `--admiralty-modal-slotted-icon-font-size`                | Font size for the modal dialog slotted icon      |
-| `--admiralty-modal-slotted-text-font-size`                | Font size for the modal dialog slotted text      |
+| Name                                                      | Description                                              |
+| --------------------------------------------------------- | -------------------------------------------------------- |
+| `--admiralty-modal-dialog-content-padding`                | Padding for the modal dialog content                     |
+| `--admiralty-modal-dialog-content-slotted-button-padding` | Padding for the modal dialog content button slot         |
+| `--admiralty-modal-dialog-content-slotted-margin-bottom`  | Margin bottom for the modal dialog content slot          |
+| `--admiralty-modal-dialog-content-slotted-padding`        | Padding for the modal dialog content slot                |
+| `--admiralty-modal-dialog-heading-margin-bottom`          | Margin bottom for the modal dialog heading               |
+| `--admiralty-modal-dialog-heading-padding`                | Padding for the modal dialog heading                     |
+| `--admiralty-modal-dialog-margin`                         | Margin for the modal dialog.                             |
+| `--admiralty-modal-heading-font-size`                     | Font size for the modal dialog heading                   |
+| `--admiralty-modal-heading-font-size-mobile`              | Font size for the modal dialog heading on mobile devices |
+| `--admiralty-modal-heading-font-weight`                   | Font weight for the modal dialog heading                 |
+| `--admiralty-modal-slotted-icon-font-size`                | Font size for the modal dialog slotted icon              |
+| `--admiralty-modal-slotted-text-font-size`                | Font size for the modal dialog slotted text              |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/core/src/components/modal-dialog/readme.md
+++ b/packages/core/src/components/modal-dialog/readme.md
@@ -85,7 +85,7 @@ The modal dialog component meets WCAG 2.2 AA standards:
 - **Focus Trapping**: Focus is trapped within the dialog when open
 - **Focus Management**: Focus automatically moves to the first interactive element when the dialog opens
 - **Focus Restoration**: Focus returns to the element that triggered the modal when it closes
-- **Keyboard Navigation**: Users can navigate between focusable elements using Tab/Shift+Tab; Escape closes the dialog
+- **Keyboard Navigation**: Users can navigate between focusable elements using Tab/Shift+Tab
 - **Screen Reader Support**: The dialog is announced with an accessible name (from `label` or `heading`) and description
 - **Touch Targets**: On mobile, buttons are full-width, meeting WCAG 2.2 target size recommendations (44×44 CSS px)
 

--- a/packages/core/src/components/modal-dialog/readme.md
+++ b/packages/core/src/components/modal-dialog/readme.md
@@ -91,6 +91,7 @@ The modal dialog component meets WCAG 2.2 AA standards:
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
 | Property      | Attribute     | Description                          | Type      | Default     |
@@ -100,12 +101,14 @@ The modal dialog component meets WCAG 2.2 AA standards:
 | `label`       | `label`       | Label the dialog.                    | `string`  | `undefined` |
 | `show`        | `show`        | Whether to show the modal dialog.    | `boolean` | `false`     |
 
+
 ## Slots
 
 | Slot        | Description             |
 | ----------- | ----------------------- |
 | `"actions"` | Actions for the dialog. |
 | `"content"` | Content of the dialog.  |
+
 
 ## CSS Custom Properties
 
@@ -124,6 +127,7 @@ The modal dialog component meets WCAG 2.2 AA standards:
 | `--admiralty-modal-slotted-icon-font-size`                | Font size for the modal dialog slotted icon              |
 | `--admiralty-modal-slotted-text-font-size`                | Font size for the modal dialog slotted text              |
 
----
 
-_Built with [StencilJS](https://stenciljs.com/)_
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/website/src/app/components/modal-dialog/modal-dialog.mdx
+++ b/packages/website/src/app/components/modal-dialog/modal-dialog.mdx
@@ -16,6 +16,20 @@ import Basic from "@/usage/modal-dialog/basic/index.mdx";
 
 Use the label and description props to provide better accessibility for the modal dialog.
 
+The modal traps focus while open, closes on Escape, and returns focus to the previously focused trigger when it closes.
+
+## Responsive behaviour
+
+At desktop and tablet widths the modal keeps its current centred layout.
+
+Below the small breakpoint, the dialog becomes fluid-width within the viewport, keeps the same heading and content alignment, and stacks actions vertically in the footer band with the primary action first.
+
+Use the default action markup order shown in the examples. The component automatically promotes the primary action above secondary actions on phone-sized viewports so existing consumers do not need to change their templates.
+
+## Mobile example
+
+Open the basic example in a narrow viewport to see the mobile layout. The primary action spans the full footer width and appears above the secondary action.
+
 ## Content Design
 
 When using the modal dialogue, you must:


### PR DESCRIPTION
- Update modal dialog styles for mobile responsiveness, including max-width and max-height adjustments.
- Modify modal dialog properties to allow optional heading, label, and description.
- Enhance accessibility features by ensuring focus trapping and restoration.
- Add tests to verify mobile behavior and action button ordering.
- Update documentation to reflect responsive behavior and usage examples.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.9.0--canary.516.c8982d2.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ukho/admiralty-angular@5.9.0--canary.516.c8982d2.0
  npm install @ukho/admiralty-core@5.9.0--canary.516.c8982d2.0
  npm install @ukho-internal/admiralty-docs@5.9.0--canary.516.c8982d2.0
  npm install @ukho/admiralty-react@5.9.0--canary.516.c8982d2.0
  npm install test-app@5.9.0--canary.516.c8982d2.0
  npm install website@5.9.0--canary.516.c8982d2.0
  # or 
  yarn add @ukho/admiralty-angular@5.9.0--canary.516.c8982d2.0
  yarn add @ukho/admiralty-core@5.9.0--canary.516.c8982d2.0
  yarn add @ukho-internal/admiralty-docs@5.9.0--canary.516.c8982d2.0
  yarn add @ukho/admiralty-react@5.9.0--canary.516.c8982d2.0
  yarn add test-app@5.9.0--canary.516.c8982d2.0
  yarn add website@5.9.0--canary.516.c8982d2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
